### PR TITLE
Add copyright notices to source files missing them

### DIFF
--- a/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform.cpp
+++ b/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) 2022 Rabbit Hole Computing™
+
 #include "BlueSCSI_platform.h"
 #include "BlueSCSI_log.h"
 #include "BlueSCSI_config.h"

--- a/lib/BlueSCSI_platform_RP2040/rp2040_sdio.cpp
+++ b/lib/BlueSCSI_platform_RP2040/rp2040_sdio.cpp
@@ -1,4 +1,5 @@
 // Implementation of SDIO communication for RP2040
+// Copyright (c) 2022 Rabbit Hole Computing™
 //
 // The RP2040 official work-in-progress code at
 // https://github.com/raspberrypi/pico-extras/tree/master/src/rp2_common/pico_sd_card

--- a/lib/BlueSCSI_platform_RP2040/rp2040_sdio.pio
+++ b/lib/BlueSCSI_platform_RP2040/rp2040_sdio.pio
@@ -1,6 +1,8 @@
 ; RP2040 PIO program for implementing SD card access in SDIO mode
 ; Run "pioasm rp2040_sdio.pio rp2040_sdio.pio.h" to regenerate the C header from this.
-
+;
+; Copyright (c) 2022 Rabbit Hole Computing™
+;
 ; The RP2040 official work-in-progress code at
 ; https://github.com/raspberrypi/pico-extras/tree/master/src/rp2_common/pico_sd_card
 ; may be useful reference, but this is independent implementation.

--- a/lib/BlueSCSI_platform_RP2040/scsiHostPhy.cpp
+++ b/lib/BlueSCSI_platform_RP2040/scsiHostPhy.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) 2022 Rabbit Hole Computing™
+
 #include "scsiHostPhy.h"
 #include "BlueSCSI_platform.h"
 #include "BlueSCSI_log.h"

--- a/lib/BlueSCSI_platform_RP2040/scsiPhy.cpp
+++ b/lib/BlueSCSI_platform_RP2040/scsiPhy.cpp
@@ -1,5 +1,8 @@
 // Implements the low level interface to SCSI bus
 // Partially derived from scsiPhy.c from SCSI2SD-V6
+//
+// Copyright (c) 2022 Rabbit Hole Computing™
+// Copyright (c) 2014 Michael McMaster
 
 #include "scsiPhy.h"
 #include "BlueSCSI_platform.h"

--- a/lib/BlueSCSI_platform_RP2040/scsi_accel.pio
+++ b/lib/BlueSCSI_platform_RP2040/scsi_accel.pio
@@ -1,4 +1,7 @@
 ; RP2040 PIO program for accelerating SCSI communication
+;
+; Copyright (c) 2022 Rabbit Hole Computing™
+;
 ; Run "pioasm scsi_accel.pio scsi_accel.pio.h" to regenerate the C header from this.
 ; GPIO mapping:
 ; - 0-7: DB0-DB7

--- a/lib/BlueSCSI_platform_RP2040/scsi_accel_host.cpp
+++ b/lib/BlueSCSI_platform_RP2040/scsi_accel_host.cpp
@@ -1,4 +1,5 @@
 // Accelerated SCSI subroutines for SCSI initiator/host side communication
+// Copyright (c) 2022 Rabbit Hole Computing™
 
 #include "scsi_accel_host.h"
 #include "BlueSCSI_platform.h"

--- a/lib/BlueSCSI_platform_RP2040/scsi_accel_host.pio
+++ b/lib/BlueSCSI_platform_RP2040/scsi_accel_host.pio
@@ -1,4 +1,7 @@
 ; RP2040 PIO program for accelerating SCSI initiator / host function
+;
+; Copyright (c) 2022 Rabbit Hole Computing™
+;
 ; Run "pioasm scsi_accel_host.pio scsi_accel_host.pio.h" to regenerate the C header from this.
 ; GPIO mapping:
 ; - 0-7: DB0-DB7

--- a/lib/BlueSCSI_platform_RP2040/scsi_accel_rp2040.cpp
+++ b/lib/BlueSCSI_platform_RP2040/scsi_accel_rp2040.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) 2022 Rabbit Hole Computing™
+
 /* Data flow in SCSI acceleration:
  *
  * 1. Application provides a buffer of bytes to send.

--- a/lib/BlueSCSI_platform_RP2040/sd_card_sdio.cpp
+++ b/lib/BlueSCSI_platform_RP2040/sd_card_sdio.cpp
@@ -1,4 +1,6 @@
 // Driver for accessing SD card in SDIO mode on RP2040.
+//
+// Copyright (c) 2022 Rabbit Hole Computing™
 
 #include "BlueSCSI_platform.h"
 

--- a/lib/BlueSCSI_platform_RP2040/sd_card_spi.cpp
+++ b/lib/BlueSCSI_platform_RP2040/sd_card_spi.cpp
@@ -1,4 +1,6 @@
 // Driver and interface for accessing SD card in SPI mode
+//
+// Copyright (c) 2022 Rabbit Hole Computing™
 
 #include "BlueSCSI_platform.h"
 #include "BlueSCSI_log.h"

--- a/src/BlueSCSI_bootloader.cpp
+++ b/src/BlueSCSI_bootloader.cpp
@@ -1,4 +1,6 @@
 // Simple bootloader that loads new firmware from SD card.
+//
+// Copyright (c) 2022 Rabbit Hole Computing™
 
 #include <BlueSCSI_platform.h>
 #include "BlueSCSI_config.h"

--- a/src/BlueSCSI_log.cpp
+++ b/src/BlueSCSI_log.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) 2022 Rabbit Hole Computing™
+
 #include "BlueSCSI_log.h"
 #include "BlueSCSI_config.h"
 #include "BlueSCSI_platform.h"

--- a/src/BlueSCSI_log.h
+++ b/src/BlueSCSI_log.h
@@ -1,4 +1,5 @@
 // Helpers for log messages.
+// Copyright (c) 2022 Rabbit Hole Computing™
 
 #pragma once
 

--- a/src/BlueSCSI_log_trace.cpp
+++ b/src/BlueSCSI_log_trace.cpp
@@ -1,4 +1,6 @@
 // SCSI trace logging
+//
+// Copyright (c) 2022 Rabbit Hole Computing™
 
 #include "BlueSCSI_log_trace.h"
 #include "BlueSCSI_log.h"

--- a/src/build_bootloader.py
+++ b/src/build_bootloader.py
@@ -1,6 +1,8 @@
 # Adds a platformio/Scons target to build the bootloader image.
 # It is basically a copy of the main firmware but using BlueSCSI_bootloader.cpp
 # as the main() function.
+#
+# Copyright (c) 2022 Rabbit Hole Computing™
 
 import os
 


### PR DESCRIPTION
I have been asked by Rabbit Hole Computing to submit this pull request to clarify the copyright on files that I have written under contract to them. It didn't occur to me at the time to add the notices, even though it is generally recommended.

This pull request adds the notices to the source files that are my work. I consider that most of the headers don't have much copyrightable content in them. If you prefer, I can add the notices to them also for consistency.

Also if you'd prefer the full GPL license declaration at the beginning of the files, I can modify this pull request.