### PR TITLE
Fix #64 - Issue with implict CD changing when hidden files are in dir

### DIFF
--- a/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform_config_hook.cpp
+++ b/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform_config_hook.cpp
@@ -83,9 +83,9 @@ void platformConfigHook(image_config_t *img)
         debuglog("Skipping platformConfigHook due to DisableConfigHook");
         return;
     }
-    if(img->file.isRom())
+    if(img->file.isRom() || img->file.isRaw())
     {
-        debuglog("Skipping platformConfigHook on ROM Drive.");
+        debuglog("Skipping platformConfigHook on ROM/Raw Drive.");
         return;
     }
     if (img->quirks == S2S_CFG_QUIRKS_APPLE)

--- a/src/BlueSCSI_disk.cpp
+++ b/src/BlueSCSI_disk.cpp
@@ -480,6 +480,11 @@ bool scsiDiskFilenameValid(const char* name)
             }
         }
     }
+    if(name[0] == '.')
+    {
+        debuglog("-- Ignoring hidden file ", name);
+        return false;
+    }
     return true;
 }
 

--- a/src/ImageBackingStore.cpp
+++ b/src/ImageBackingStore.cpp
@@ -131,6 +131,11 @@ bool ImageBackingStore::isRom()
     return m_isrom;
 }
 
+bool ImageBackingStore::isRaw()
+{
+    return m_israw;
+}
+
 bool ImageBackingStore::close()
 {
     if (m_israw)

--- a/src/ImageBackingStore.h
+++ b/src/ImageBackingStore.h
@@ -49,6 +49,9 @@ public:
     // Is this internal ROM drive in microcontroller flash?
     bool isRom();
 
+    // Is the image using the raw SD card?
+    bool isRaw();
+
     // Close the image so that .isOpen() will return false.
     bool close();
 


### PR DESCRIPTION
Skip hidden dot files sometimes created by a Mac on the SD Card.

Also add in a skip for isRaw on the platform hook as it had the same issue as the rom image.