### PR TITLE
Use a more sane default for Apple SCSI floppy drives

### DIFF
--- a/src/BlueSCSI_config.h
+++ b/src/BlueSCSI_config.h
@@ -61,7 +61,7 @@
 #define APPLE_DRIVEINFO_FIXED     {"QUANTUM",  "BlueSCSI Pico",   "1.0",  ""}
 #define APPLE_DRIVEINFO_REMOVABLE {"IOMEGA",   "BETA230",         "2.02", ""}
 #define APPLE_DRIVEINFO_OPTICAL   {"BlueSCSI", "CD-ROM CDU-55S",  "1.9a", ""}
-#define APPLE_DRIVEINFO_FLOPPY    {"TEAC",     "FD235HS",         "1.44", ""}
+#define APPLE_DRIVEINFO_FLOPPY    {"IOMEGA",     "Io20S         *F", "PP33", ""}
 #define APPLE_DRIVEINFO_MAGOPT    {"MOST",     "RMD-5200",        "1.0",  ""}
 #define APPLE_DRIVEINFO_TAPE      {"BlueSCSI", "APPLE_TAPE",      "",     ""}
 

--- a/src/BlueSCSI_disk.cpp
+++ b/src/BlueSCSI_disk.cpp
@@ -618,6 +618,14 @@ static void scsiDiskLoadConfig(int target_idx, const char *section)
                 log("-- SCSI ID: ", target_idx, " using Drive image directory \'", tmp, "'");
                 img.image_directory = true;
             }
+            strcpy(tmp, "FDX");
+            tmp[2] = '0' + target_idx;
+            if(SD.exists(tmp))
+            {
+                log("-- SCSI ID: ", target_idx, " using Floppy image directory \'", tmp, "'");
+                img.deviceType = S2S_CFG_FLOPPY_14MB;
+                img.image_directory = true;
+            }
         }
     }
 }


### PR DESCRIPTION
Drivers: https://macintoshgarden.org/apps/iomega-floptical

Note you can still not boot, but they are at least a usable medium now.

More info at https://github.com/PiSCSI/piscsi/wiki/Iomega-Floptical