### PR TITLE
Allow signals to settle on REQ pulse

### DIFF
--- a/lib/BlueSCSI_platform_RP2040/scsi_accel_host.pio
+++ b/lib/BlueSCSI_platform_RP2040/scsi_accel_host.pio
@@ -20,6 +20,7 @@
 
 start:
     wait 0 gpio REQ             side 1  ; Wait for REQ low
+    nop                 [1]     side 1  ; Wait for signals to settle
     in pins, 9                  side 0  ; Assert ACK, read GPIO
     in null, 7                  side 0  ; Padding bits
     wait 1 gpio REQ             side 0  ; Wait for REQ high

--- a/lib/BlueSCSI_platform_RP2040/scsi_accel_host.pio.h
+++ b/lib/BlueSCSI_platform_RP2040/scsi_accel_host.pio.h
@@ -13,24 +13,25 @@
 // -------------------- //
 
 #define scsi_host_async_read_wrap_target 0
-#define scsi_host_async_read_wrap 6
+#define scsi_host_async_read_wrap 7
 
 static const uint16_t scsi_host_async_read_program_instructions[] = {
             //     .wrap_target
     0x90a0, //  0: pull   block           side 1     
     0xb027, //  1: mov    x, osr          side 1     
     0x3013, //  2: wait   0 gpio, 19      side 1     
-    0x4009, //  3: in     pins, 9         side 0     
-    0x4067, //  4: in     null, 7         side 0     
-    0x2093, //  5: wait   1 gpio, 19      side 0     
-    0x1042, //  6: jmp    x--, 2          side 1     
+    0xb142, //  3: nop                    side 1 [1] 
+    0x4009, //  4: in     pins, 9         side 0     
+    0x4067, //  5: in     null, 7         side 0     
+    0x2093, //  6: wait   1 gpio, 19      side 0     
+    0x1042, //  7: jmp    x--, 2          side 1     
             //     .wrap
 };
 
 #if !PICO_NO_HARDWARE
 static const struct pio_program scsi_host_async_read_program = {
     .instructions = scsi_host_async_read_program_instructions,
-    .length = 7,
+    .length = 8,
     .origin = -1,
 };
 


### PR DESCRIPTION
Did some testing around and discovered that sometimes, bits were being flipped where they should not be during drive image operations (initiator mode).

Adding a small settle time after the REQ signal is received resolved that instability.