### PR TITLE
Initiator Mode: Disable LED on Pico W, it's causing issues for an unk…

### DIFF
--- a/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform_gpio.h
+++ b/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform_gpio.h
@@ -59,6 +59,12 @@
 #define LED_ON()     platform_network_supported() ? cyw43_gpio_set(&cyw43_state, 0, true) : sio_hw->gpio_set = 1 << LED_PIN
 #define LED_OFF()    platform_network_supported() ? cyw43_gpio_set(&cyw43_state, 0, false) : sio_hw->gpio_clr = 1 << LED_PIN
 
+#define STANDARD_LED_ON 	sio_hw->gpio_set = 1 << LED_PIN
+#define STANDARD_LED_OFF 	sio_hw->gpio_clr = 1 << LED_PIN
+
+#define W_LED_ON 	cyw43_gpio_set(&cyw43_state, 0, true)
+#define W_LED_OFF 	cyw43_gpio_set(&cyw43_state, 0, false)
+
 // SDIO and SPI block
 #define SD_SPI_SCK   10
 #define SDIO_CLK 10

--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -676,7 +676,7 @@ extern "C" void bluescsi_main_loop(void)
   platform_network_poll();
   
 #ifdef PLATFORM_HAS_INITIATOR_MODE
-  if (platform_is_initiator_mode_enabled())
+  if (unlikely(platform_is_initiator_mode_enabled()))
   {
     scsiInitiatorMainLoop();
     save_logfile();

--- a/src/BlueSCSI_initiator.cpp
+++ b/src/BlueSCSI_initiator.cpp
@@ -100,11 +100,15 @@ static void scsiInitiatorUpdateLed()
 
     if (phase <= duty)
     {
-        LED_ON();
+        if (!platform_network_supported()) {
+            STANDARD_LED_ON;
+        }
     }
     else
     {
-        LED_OFF();
+        if (!platform_network_supported()) {
+            STANDARD_LED_OFF;
+        }
     }
 }
 
@@ -143,7 +147,10 @@ void scsiInitiatorMainLoop()
 
             uint8_t inquiry_data[36];
 
-            LED_ON();
+            if (!platform_network_supported()) {
+                STANDARD_LED_ON;
+            }
+
             bool startstopok =
                 scsiTestUnitReady(g_initiator_state.target_id) &&
                 scsiStartStopUnit(g_initiator_state.target_id, true);
@@ -155,7 +162,10 @@ void scsiInitiatorMainLoop()
 
             bool inquiryok = startstopok &&
                 scsiInquiry(g_initiator_state.target_id, inquiry_data);
-            LED_OFF();
+
+            if (!platform_network_supported()) {
+                STANDARD_LED_OFF;
+            }
 
             uint64_t total_bytes = 0;
             if (readcapok)
@@ -252,7 +262,10 @@ void scsiInitiatorMainLoop()
         {
             scsiStartStopUnit(g_initiator_state.target_id, false);
             log("Finished imaging drive with id ", g_initiator_state.target_id);
-            LED_OFF();
+
+            if (!platform_network_supported()) {
+                STANDARD_LED_OFF;
+            }
 
             if (g_initiator_state.sectorcount != g_initiator_state.sectorcount_all)
             {


### PR DESCRIPTION
…nown reason


This will rather annoyingly disable the status LED for initiator mode on wifi hardware.

Can tell whether there's activity by the ACT LED on BlueSCSI's blue base board.  It will blink rapidly while data transfer is in progress, and slowly while scanning the SCSI bus.

We hope to re-enable the LED on Pico-W hardware, it'll just take some debugging to figure out what's the cause.  Disabling the LED should be a shorter term "fix".