### PR TITLE
WiFi speed tweaks

### DIFF
--- a/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform.cpp
+++ b/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform.cpp
@@ -171,7 +171,7 @@ void platform_init()
 
         // Initialize logging to SWO pin (UART0) 
         gpio_conf(SWO_PIN,        GPIO_FUNC_UART,false,false, true,  false, true);
-        uart_init(uart0, 1000000);
+        uart_init(uart0, 115200);
         g_uart_initialized = true;
     #ifdef MBED
         mbed_set_error_hook(mbed_error_hook);

--- a/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform_network.cpp
+++ b/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform_network.cpp
@@ -134,7 +134,6 @@ void platform_network_poll()
 	if (!network_in_use)
 		return;
 
-	scsiNetworkPurge();
 	cyw43_arch_poll();
 }
 

--- a/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform_network.cpp
+++ b/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform_network.cpp
@@ -93,6 +93,9 @@ int platform_network_init(char *mac)
 		log("WARNING: Wi-Fi MAC is not what was requested (%02x:%02x:%02x:%02x:%02x:%02x), is libpico not compiled with CYW43_USE_OTP_MAC=0?",
 			mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
 
+	if (scsiDev.boardCfg.wifiSCSISleep < 1)
+		scsiDev.boardCfg.wifiSCSISleep = NETWORK_DEFAULT_SCSI_SLEEP;
+		
 	network_in_use = true;
 
 	return 0;

--- a/lib/SCSI2SD/include/scsi2sd.h
+++ b/lib/SCSI2SD/include/scsi2sd.h
@@ -142,8 +142,9 @@ typedef struct __attribute__((packed))
 	char wifiMACAddress[6];
 	char wifiSSID[32];
 	char wifiPassword[63];
+	uint8_t wifiSCSISleep;
 
-	uint8_t reserved[18]; // Pad out to 128 bytes
+	uint8_t reserved[17]; // Pad out to 128 bytes
 } S2S_BoardCfg;
 
 typedef enum

--- a/lib/SCSI2SD/src/firmware/network.c
+++ b/lib/SCSI2SD/src/firmware/network.c
@@ -179,7 +179,7 @@ int scsiNetworkCommand()
 
 		if (scsiDev.dataLen > 6)
 		{
-			s2s_delay_us(80);
+			s2s_delay_us(scsiDev.boardCfg.wifiSCSISleep);
 
 			scsiWrite(scsiDev.data + 6, scsiDev.dataLen - 6);
 			while (!scsiIsWriteFinished(NULL))

--- a/lib/SCSI2SD/src/firmware/network.h
+++ b/lib/SCSI2SD/src/firmware/network.h
@@ -32,6 +32,7 @@ extern "C" {
 
 #define NETWORK_PACKET_QUEUE_SIZE   20		// must be <= 255
 #define NETWORK_PACKET_MAX_SIZE     1520
+#define NETWORK_DEFAULT_SCSI_SLEEP	60
 
 struct __attribute__((packed)) wifi_network_entry {
 	char ssid[64];

--- a/lib/SCSI2SD/src/firmware/network.h
+++ b/lib/SCSI2SD/src/firmware/network.h
@@ -54,7 +54,6 @@ struct __attribute__((packed)) wifi_join_request {
 
 int scsiNetworkCommand(void);
 int scsiNetworkEnqueue(const uint8_t *buf, size_t len);
-int scsiNetworkPurge(void);
 
 extern int platform_network_send(uint8_t *buf, size_t len);
 

--- a/src/BlueSCSI_disk.cpp
+++ b/src/BlueSCSI_disk.cpp
@@ -1062,6 +1062,8 @@ void s2s_configInit(S2S_BoardCfg* config)
     {
         memcpy(config->wifiPassword, tmp, sizeof(config->wifiPassword));
     }
+
+    config->wifiSCSISleep = ini_getl("SCSI", "WiFiSCSISleep", 0, CONFIGFILE);
 }
 
 extern "C"


### PR DESCRIPTION
Curious to see if this makes downloading faster on faster machines.

In `bluescsi.ini`, set `WiFiSCSISleep=50` or some other value lower than 60.  If it works, keep going lower until it starts breaking downloads.  The (new) default of 60 is as low as I could go on my Mac Plus.