### PR TITLE
DaynaPort Wifi compatibility for NETBSD

### DIFF
--- a/lib/SCSI2SD/include/scsi2sd.h
+++ b/lib/SCSI2SD/include/scsi2sd.h
@@ -143,7 +143,10 @@ typedef struct __attribute__((packed))
 	char wifiSSID[32];
 	char wifiPassword[63];
 
-	uint8_t reserved[18]; // Pad out to 128 bytes
+	uint8_t sendDelay;
+	uint8_t inquiry37;
+	
+	uint8_t reserved[16]; // Pad out to 128 bytes
 } S2S_BoardCfg;
 
 typedef enum

--- a/lib/SCSI2SD/src/firmware/inquiry.c
+++ b/lib/SCSI2SD/src/firmware/inquiry.c
@@ -163,6 +163,8 @@ void s2s_scsiInquiry()
 		{
 			allocationLength = 254;
 		}
+		if (allocationLength == 37)
+			scsiDev.boardCfg.inquiry37 = 1;
 
 		// "real" hard drives send back exactly allocationLenth bytes, padded
 		// with zeroes. This only seems to happen for Inquiry responses, and not

--- a/src/BlueSCSI_disk.cpp
+++ b/src/BlueSCSI_disk.cpp
@@ -955,6 +955,8 @@ void s2s_configInit(S2S_BoardCfg* config)
     config->selectionDelay = ini_getl("SCSI", "SelectionDelay", defaults.selectionDelay, CONFIGFILE);
     config->flags6 = 0;
     config->scsiSpeed = PLATFORM_MAX_SCSI_SPEED;
+    config->sendDelay = 80;
+    config->inquiry37 = 0;
 
     int maxSyncSpeed = ini_getl("SCSI", "MaxSyncSpeed", defaults.maxSyncSpeed, CONFIGFILE);
     if (maxSyncSpeed < 5 && config->scsiSpeed > S2S_CFG_SPEED_ASYNC_50)


### PR DESCRIPTION
This change applies the send delay to MacOS only and uses a minimum packet size of 128 bytes.

Tested with a Macintosh  SE/30 running MacOS 7.6.1 and then booting either NetBSD 3.1.1 or NetBSD 9.3 built with dse driver.

Refer also to recent similar changes made in the develop branch of the SCSI2Pi project. 