### PR TITLE
More initiator fixes

### DIFF
--- a/src/BlueSCSI_initiator.cpp
+++ b/src/BlueSCSI_initiator.cpp
@@ -314,7 +314,7 @@ void scsiInitiatorMainLoop()
 
             if (g_initiator_state.retrycount < 5)
             {
-                log("Retrying.. ", g_initiator_state.retrycount, "/5");
+                log("Retrying.. ", g_initiator_state.retrycount + 1, "/5");
                 delay_with_poll(200);
                 // This reset causes some drives to hang and seems to have no effect if left off.
                 // scsiHostPhyReset();

--- a/src/BlueSCSI_initiator.cpp
+++ b/src/BlueSCSI_initiator.cpp
@@ -316,7 +316,8 @@ void scsiInitiatorMainLoop()
             {
                 log("Retrying.. ", g_initiator_state.retrycount, "/5");
                 delay_with_poll(200);
-                scsiHostPhyReset();
+                // This reset causes some drives to hang and seems to have no effect if left off.
+                // scsiHostPhyReset();
                 delay_with_poll(200);
 
                 g_initiator_state.retrycount++;

--- a/src/BlueSCSI_initiator.cpp
+++ b/src/BlueSCSI_initiator.cpp
@@ -353,9 +353,9 @@ void scsiInitiatorMainLoop()
             g_initiator_state.target_file.flush();
 
             int speed_kbps = numtoread * g_initiator_state.sectorsize / (millis() - time_start);
-            log("SCSI read succeeded, sectors done: ",
-                  (int)g_initiator_state.sectors_done, " / ", (int)g_initiator_state.sectorcount,
-                  " speed ", speed_kbps, " kB/s");
+            log_f("SCSI read succeeded, sectors done: %d / %d speed %d kB/s - %.2f%%",
+                  g_initiator_state.sectors_done, g_initiator_state.sectorcount, speed_kbps,
+                  (float)(((float)g_initiator_state.sectors_done / (float)g_initiator_state.sectorcount) * 100.0));
         }
     }
 }

--- a/src/BlueSCSI_initiator.cpp
+++ b/src/BlueSCSI_initiator.cpp
@@ -251,7 +251,7 @@ void scsiInitiatorMainLoop()
                 {
                     log("Using filename: ", filename, " to avoid overwriting existing file.");
                 }
-                g_initiator_state.target_file = SD.open(filename, O_RDWR | O_CREAT | O_TRUNC);
+                g_initiator_state.target_file = SD.open(filename, O_WRONLY | O_CREAT | O_TRUNC);
                 if (!g_initiator_state.target_file.isOpen())
                 {
                     log("Failed to open file for writing: ", filename);

--- a/src/BlueSCSI_initiator.cpp
+++ b/src/BlueSCSI_initiator.cpp
@@ -511,7 +511,7 @@ bool scsiRequestSense(int target_id, uint8_t *sense_key)
 
     log("RequestSense response: ", bytearray(response, 18));
 
-    *sense_key = response[2];
+    *sense_key = response[2] & 0x0F;
     return status == 0;
 }
 

--- a/src/BlueSCSI_initiator.h
+++ b/src/BlueSCSI_initiator.h
@@ -5,6 +5,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#define DEVICE_TYPE_CD 5
+#define DEVICE_TYPE_DIRECT_ACCESS 0
+
 void scsiInitiatorInit();
 
 void scsiInitiatorMainLoop();


### PR DESCRIPTION
Going though a box of SCSI drives I found. Fixes so far:

- Correctly ID SCSI-1 drives
- Don't reset bus - causes some drives to hang, no issues if skipped.
- Fix logging of retry count
- Fix image file opening as readable when never read from
- Report how many unrecoverable bad sectors were found.
- Print % complete in log.
- `InitatorMaxRetry` - default 5 - min 0 -> max 255
- Eject and continue scanning IDs that have CD's or Eject-able media.
- Fix incorrect sense key parsing.