### PR TITLE
SCSI3 Initiator Mode Fix

### DIFF
--- a/src/BlueSCSI_initiator.cpp
+++ b/src/BlueSCSI_initiator.cpp
@@ -214,7 +214,7 @@ void scsiInitiatorMainLoop()
                     g_initiator_state.sectorsize = 0;
                     g_initiator_state.sectorcount = g_initiator_state.sectorcount_all = 0;
                 }
-                if(g_initiator_state.ansiVersion != 0x02)
+                if(g_initiator_state.ansiVersion < 0x02)
                 {
                     // this is a SCSI-1 drive, use READ6 and 256 bytes to be safe.
                     g_initiator_state.max_sector_per_transfer = 256;
@@ -727,7 +727,7 @@ bool scsiInitiatorReadDataToFile(int target_id, uint32_t start_sector, uint32_t 
 
     // Read6 command supports 21 bit LBA - max of 0x1FFFFF
     // ref: https://www.seagate.com/files/staticfiles/support/docs/manual/Interface%20manuals/100293068j.pdf pg 134
-    if (g_initiator_state.ansiVersion != 0x02 || (start_sector < 0x1FFFFF && sectorcount <= 256))
+    if (g_initiator_state.ansiVersion < 0x02 || (start_sector < 0x1FFFFF && sectorcount <= 256))
     {
         // Use READ6 command for compatibility with old SCSI1 drives
         uint8_t command[6] = {0x08,


### PR DESCRIPTION
One of my SCSI3 drives refused to image properly, this updates the check for SCSI1 to only be on SCSI versions less than 2 instead of "not 2".