### PR TITLE
scsi: inquiry response to invalid lun

### DIFF
--- a/lib/SCSI2SD/src/firmware/scsi.c
+++ b/lib/SCSI2SD/src/firmware/scsi.c
@@ -413,14 +413,7 @@ static void process_Command()
 	}
 	else if (command == 0x12)
 	{
-		if(scsiDev.lun)
-		{
-			scsiDev.target->sense.code = ILLEGAL_REQUEST;
-			scsiDev.target->sense.asc = LOGICAL_UNIT_NOT_SUPPORTED;
-			enter_Status(CHECK_CONDITION);
-		} else {
-			s2s_scsiInquiry();
-		}
+		s2s_scsiInquiry();
 	}
 	else if (command == 0x03)
 	{


### PR DESCRIPTION
 inquiry should respond to invalid LUNs and set peripheral qualifier and peripheral device-type fields to 0x7F. 

Fixes #127. Tested by @uweseimet 