### PR TITLE
Changes to DynaPORT to allow the amiga A590/A2091 and GVP scsi interfaces to use it

### DIFF
--- a/lib/SCSI2SD/src/firmware/network.c
+++ b/lib/SCSI2SD/src/firmware/network.c
@@ -105,7 +105,7 @@ int scsiNetworkCommand()
 	DBGMSG_F("------ in scsiNetworkCommand with command 0x%02x (size %d)", command, size);
 
 	// Rather than duplicating code, this just diverts a 'fake' read request to make the gvpscsi.device happy on the Amiga
-	if ((command == SCSI_NETWORK_WIFI_CMD) && (scsiDev.cdb[1] == SCSI_METWORK_WIFI_CMD_ALTREAD)) {
+	if ((scsiDev.cdb[0] == SCSI_NETWORK_WIFI_CMD) && (scsiDev.cdb[1] == SCSI_NETWORK_WIFI_CMD_ALTREAD)) {
 		// Redirect the command as a READ.
 		command = 0x08;
 	}
@@ -163,7 +163,7 @@ int scsiNetworkCommand()
 			DBGMSG_BUF(scsiDev.data, scsiDev.dataLen);
 		}
 		// Patches around the weirdness on the Amiga SCSI devices
-		if ((scsiDev.cdb[2] == AMIGASCSI_PATCH_24BYTE_BLOCKSIZE) || (scsiDev.cdb[2] == AMIGASCSI_PATCH_SINGLEWRITE_ONLY)) {
+		if ((scsiDev.cdb[0] == SCSI_NETWORK_WIFI_CMD) && (scsiDev.cdb[1] == SCSI_NETWORK_WIFI_CMD_ALTREAD)) {
 			scsiDev.data[2] = scsiDev.cdb[2];    // for me really
 			int extra = 0;
 			if (scsiDev.cdb[2] == AMIGASCSI_PATCH_24BYTE_BLOCKSIZE) {        

--- a/lib/SCSI2SD/src/firmware/network.c
+++ b/lib/SCSI2SD/src/firmware/network.c
@@ -430,7 +430,7 @@ int scsiNetworkCommand()
 		}
 
 		case SCSI_NETWORK_WIFI_GETMACADDRESS: 
-			// Update for the gvpscsi.device on the Amiga
+			// Update for the gvpscsi.device on the Amiga as it doesn't like 0x09 command being called!
 			memcpy(scsiDev.data, scsiDev.boardCfg.wifiMACAddress, sizeof(scsiDev.boardCfg.wifiMACAddress));
 			memset(scsiDev.data + sizeof(scsiDev.boardCfg.wifiMACAddress), 0, sizeof(scsiDev.data) - sizeof(scsiDev.boardCfg.wifiMACAddress));
 

--- a/lib/SCSI2SD/src/firmware/network.h
+++ b/lib/SCSI2SD/src/firmware/network.h
@@ -29,7 +29,12 @@ extern "C" {
 #define SCSI_NETWORK_WIFI_CMD_SCAN_RESULTS	0x03
 #define SCSI_NETWORK_WIFI_CMD_INFO			0x04
 #define SCSI_NETWORK_WIFI_CMD_JOIN			0x05
-#define SCSI_NETWORK_WIFI_GETMACADDRESS     0x09   // gvpscsi.device on AMIGA doesnt like the standard version
+
+// Patches to make the DaynaPORT (or whats left of it) work on the Amiga - RobSmithDev
+#define SCSI_METWORK_WIFI_CMD_ALTREAD       0x08   // gvpscsi.device on AMIGA doesnt like the standard version      
+#define SCSI_NETWORK_WIFI_CMD_GETMACADDRESS 0x09   // gvpscsi.device on AMIGA doesnt like the standard version
+#define AMIGASCSI_PATCH_24BYTE_BLOCKSIZE 	0xF8   // In this mode, data written is rounded up to the nearest 24-byte boundary
+#define AMIGASCSI_PATCH_SINGLEWRITE_ONLY 	0xF9   // In this mode, data written is always ONLY as one single write command
 
 #define NETWORK_PACKET_QUEUE_SIZE   20		// must be <= 255
 #define NETWORK_PACKET_MAX_SIZE     1520

--- a/lib/SCSI2SD/src/firmware/network.h
+++ b/lib/SCSI2SD/src/firmware/network.h
@@ -29,6 +29,7 @@ extern "C" {
 #define SCSI_NETWORK_WIFI_CMD_SCAN_RESULTS	0x03
 #define SCSI_NETWORK_WIFI_CMD_INFO			0x04
 #define SCSI_NETWORK_WIFI_CMD_JOIN			0x05
+#define SCSI_NETWORK_WIFI_GETMACADDRESS     0x09   // gvpscsi.device on AMIGA doesnt like the standard version
 
 #define NETWORK_PACKET_QUEUE_SIZE   20		// must be <= 255
 #define NETWORK_PACKET_MAX_SIZE     1520

--- a/lib/SCSI2SD/src/firmware/network.h
+++ b/lib/SCSI2SD/src/firmware/network.h
@@ -31,10 +31,11 @@ extern "C" {
 #define SCSI_NETWORK_WIFI_CMD_JOIN			0x05
 
 // Patches to make the DaynaPORT (or whats left of it) work on the Amiga - RobSmithDev
-#define SCSI_METWORK_WIFI_CMD_ALTREAD       0x08   // gvpscsi.device on AMIGA doesnt like the standard version      
+#define SCSI_NETWORK_WIFI_CMD_ALTREAD       0x08   // gvpscsi.device on AMIGA doesnt like the standard version      
 #define SCSI_NETWORK_WIFI_CMD_GETMACADDRESS 0x09   // gvpscsi.device on AMIGA doesnt like the standard version
-#define AMIGASCSI_PATCH_24BYTE_BLOCKSIZE 	0xF8   // In this mode, data written is rounded up to the nearest 24-byte boundary
-#define AMIGASCSI_PATCH_SINGLEWRITE_ONLY 	0xF9   // In this mode, data written is always ONLY as one single write command
+
+#define AMIGASCSI_PATCH_24BYTE_BLOCKSIZE 	0xA8   // In this mode, data written is rounded up to the nearest 24-byte boundary
+#define AMIGASCSI_PATCH_SINGLEWRITE_ONLY 	0xA9   // In this mode, data written is always ONLY as one single write command
 
 #define NETWORK_PACKET_QUEUE_SIZE   20		// must be <= 255
 #define NETWORK_PACKET_MAX_SIZE     1520


### PR DESCRIPTION
I've written a network driver for the Amiga to use the DynaPORT interface on BlueSCSI.

During my testing I discovered a strange problem with the way the A590 (scsi.device on the Amiga) was handling data received from the DynaPORT read command. I discovered that unless the data received was a multiple of 24 bytes, the trailing end of these bytes didn't get received proerply and never ended up in the buffer received from the driver, even though it claims to have read this amount.

With the GVP SCSI interface (gvpscsi.device) Firstly, issuing the command to request the MAC address caused the driver to throw a GVP invalid status message instantly.  The same also happened when calling READ with larger network packets.  For example ping replies didnt cause a problem, but downloading files did.

To fix these issues I created an extra two extra SCSI_NETWORK_WIFI_CMD sub commands. One as an alternative method for obtaining the MAC address (which only sends back 6 bytes) and the other as an alternative READ command, which simply redirects it back at the original code but with some flags.

To make sure I dont mess up the existing solution, the new code will only trigger if this special READ command was used.
If it was, it has two modes.  One will perform the rounding up to 24-bytes, with code to ensure no buffer overrun occurs. The other mode performs a single write including the header, instead of the two (header, delay, data) the original DynaPORT read did.

I've had these on test for a few days and seems stable enough. I'm planning on pushing the driver public on GitHub from Sunday 3rd to coinside with a video on my YouTube channel.  If you'd like access to either of these materials beforehand please message me.