### PR TITLE
scsi: fix mac vendor page

### DIFF
--- a/lib/SCSI2SD/src/firmware/mode.c
+++ b/lib/SCSI2SD/src/firmware/mode.c
@@ -525,7 +525,6 @@ static void doModeSense(
 	idx += modeSenseCDCapabilitiesPage(pc, idx, pageCode, &pageFound);
 
 	if ((scsiDev.target->cfg->quirks == S2S_CFG_QUIRKS_APPLE) &&
-	    (idx + sizeof(AppleVendorPage) <= allocLength) &&
 		(pageCode == 0x30 || pageCode == 0x3F))
 	{
 		pageFound = 1;


### PR DESCRIPTION
In SCSI2SD 4.1.1 circa 2015 c09e15bac64b996d09174a3670773c1c48b6458e there was a bug introduced that incorrectly checked the allocation length of the Apple Vendor page. This worked as it was silently truncating the response. But did cause the vendor string to always be sent even if Apple Quirks was disabled.

In upstream 0abf488eeb6037adb0e367964f3024b8733a5433 an attempt was made to fix this, but it was not tested with Apple’s formatting utilities as it does not work.

After validating with multiple real apple firmware drives the correct behavior is to truncate the page. This is the same behavior as every other page being sent. Note newer drives page code is actually this longer variant but older ones have a shorter length. The Apple formatting tools ignore the page length field when doing their checks so was left as the longer variant, truncated.