### PR TITLE
PIO base file did not match compiled PIO header file

### DIFF
--- a/lib/BlueSCSI_platform_RP2040/rp2040_sdio.pio
+++ b/lib/BlueSCSI_platform_RP2040/rp2040_sdio.pio
@@ -24,8 +24,8 @@
 ; edge, it is preferrable to have a long 0 state and short 1 state.
 ;.define CLKDIV 3
 .define CLKDIV 5
-.define D0 ((CLKDIV + 1) / 2 - 1)
-.define D1 (CLKDIV/2 - 1)
+.define D0 (((CLKDIV + 1) /2) - 1)
+.define D1 ((CLKDIV/2) - 1)
 .define SDIO_CLK_GPIO 10
 
 ; State machine 0 is used to:

--- a/lib/BlueSCSI_platform_RP2040/rp2040_sdio.pio.h
+++ b/lib/BlueSCSI_platform_RP2040/rp2040_sdio.pio.h
@@ -64,8 +64,7 @@ static const uint16_t sdio_data_rx_program_instructions[] = {
             //     .wrap_target
     0xa022, //  0: mov    x, y                       
     0x2020, //  1: wait   0 pin, 0                   
-    //0x2492, //  2: wait   1 gpio, 18             [4] 
-    0x248A, // 2: wait 1 gpio 10
+    0x248a, //  2: wait   1 gpio, 10             [4] 
     0x4304, //  3: in     pins, 4                [3] 
     0x0043, //  4: jmp    x--, 3                     
             //     .wrap
@@ -93,10 +92,8 @@ static inline pio_sm_config sdio_data_rx_program_get_default_config(uint offset)
 #define sdio_data_tx_wrap 8
 
 static const uint16_t sdio_data_tx_program_instructions[] = {
-    // 0x2012, //  0: wait   0 gpio, 18                 
-    0x200A,  // 0: wait 0 GPIO 10
-   // 0x2592, //  1: wait   1 gpio, 18             [5] 
-    0x258A, // 1: wait 1 gpio 10
+    0x200a, //  0: wait   0 gpio, 10                 
+    0x258a, //  1: wait   1 gpio, 10             [5] 
     0x6204, //  2: out    pins, 4                [2] 
     0x0142, //  3: jmp    x--, 2                 [1] 
     0xe280, //  4: set    pindirs, 0             [2] 


### PR DESCRIPTION
Fixed define logic to make them match, and regenerated PIO header file.
Note that the hex instructions in .pio.h are unchanged, there were just some comments removed by regenerating the header file.