### PR TITLE
Configurable SDIO Clocking

### DIFF
--- a/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform.h
+++ b/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform.h
@@ -93,6 +93,7 @@ bool is202309a();
 // This can be used to implement simultaneous transfer to SCSI bus.
 typedef void (*sd_callback_t)(uint32_t bytes_complete);
 void platform_set_sd_callback(sd_callback_t func, const uint8_t *buffer);
+void add_extra_sdio_delay(uint16_t additional_delay);
 
 // Reprogram firmware in main program area.
 #ifndef RP2040_DISABLE_BOOTLOADER

--- a/lib/BlueSCSI_platform_RP2040/rp2040_sdio.h
+++ b/lib/BlueSCSI_platform_RP2040/rp2040_sdio.h
@@ -58,3 +58,6 @@ sdio_status_t receive_status_register(uint8_t* sds);
 
 // (Re)initialize the SDIO interface
 void rp2040_sdio_init(int clock_divider = 1);
+
+// Adds extra clock delay as specified in additional_delay
+void rp2040_sdio_delay_increment(uint16_t additional_delay);

--- a/lib/BlueSCSI_platform_RP2040/sd_card_sdio.cpp
+++ b/lib/BlueSCSI_platform_RP2040/sd_card_sdio.cpp
@@ -45,6 +45,10 @@ void platform_set_sd_callback(sd_callback_t func, const uint8_t *buffer)
     m_stream_count_start = 0;
 }
 
+void add_extra_sdio_delay(uint16_t additional_delay) {
+    rp2040_sdio_delay_increment(additional_delay);
+}
+
 static sd_callback_t get_stream_callback(const uint8_t *buf, uint32_t count, const char *accesstype, uint32_t sector)
 {
     m_stream_count_start = m_stream_count;

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@ default_envs = BlueSCSI_Pico
 
 ; BlueSCSI RP2040 hardware platform, based on the Raspberry Pi foundation RP2040 microcontroller
 [env:BlueSCSI_Pico]
-platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git#196d31bbafaf60b84751b1a415d8dca2365debdf
 platform_packages = platformio/toolchain-gccarmnoneeabi@1.120301.0
     framework-arduinopico@https://github.com/BlueSCSI/arduino-pico-internal.git#e139b9c7816602597f473b3231032cca5d71a48a
 framework = arduino

--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -600,6 +600,20 @@ extern "C" void bluescsi_setup(void)
       log("SD card without filesystem!");
     }
 
+    long add_sdio_delay = ini_getl("SDIO", "AddClockDelay", 0, CONFIGFILE);
+    if (add_sdio_delay) {
+      if (add_sdio_delay < 0) {
+        add_sdio_delay = 0;
+        log("---- WARNING: Negative numbers are not valid for AddClockDelay. Setting value to 0");
+      }
+      if (add_sdio_delay > 2) {
+        add_sdio_delay = 2;
+        log("---- WARNING: Max value 2 exceeded for AddClockDelay. Setting value to 2.");
+      }
+      log("INFO: Injecting ", (uint16_t)add_sdio_delay, " additional wait state(s) on SDIO");
+      add_extra_sdio_delay((uint16_t) add_sdio_delay);
+    }
+
     print_sd_info();
   
     reinitSCSI();

--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -758,6 +758,7 @@ extern "C" void bluescsi_main_loop(void)
 
         reinitSCSI();
         init_logfile();
+        LED_OFF();
       }
       else if (!g_romdrive_active)
       {

--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -559,8 +559,8 @@ void check_and_apply_sdio_delay() {
   long add_sdio_delay = ini_getl("SDIO", "AddClockDelay", 0, CONFIGFILE);
   if (add_sdio_delay) {
     if (add_sdio_delay < 0) {
-      add_sdio_delay = 0;
       log("---- WARNING: Negative numbers are not valid for AddClockDelay. Setting value to 0");
+      return;
     }
     if (add_sdio_delay > 2) {
       add_sdio_delay = 2;


### PR DESCRIPTION
These changes are designed to try and mitigate the effects of using BlueSCSI in a high-EMI environment.  High-noise environments are causing disruption of the SDIO bus, which usually manifests as disk image write issues and log entries such as the following:
`SDIO card reports write CRC error, status 0x000000EB`

This mitigation does result in an overall read/write speed decrease.  On my PowerMac 7300, max read speeds usually run around 8000k and max write speeds around 4800k.  With mitigation level 2 in place this drops to 7000k read and 3800k write.

To configure this mitigation, place these lines in your bluescsi.ini file.  Only `1` and `2` are valid for this configuration, with increasing slowdown when 2 is specified.
```
[SDIO]
AddClockDelay=1
```