### PR TITLE
Pico 2

### DIFF
--- a/.github/workflows/firmware_build.yml
+++ b/.github/workflows/firmware_build.yml
@@ -15,15 +15,17 @@ jobs:
         with:
           path: BlueSCSI
           fetch-depth: "0"
-
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - name: Install platformio
         run: |
-          sudo pip install platformio
+          pip install --upgrade platformio
 
       - name: Build firmware
         run: |
           cd BlueSCSI
-          pio run -v
+          pio run -e BlueSCSI_Pico2 -v
 
       - name: Rename firmware files
         run: |

--- a/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform.cpp
+++ b/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform.cpp
@@ -573,7 +573,9 @@ static void watchdog_callback(unsigned alarm_num)
 #ifdef __MBED__
             uint32_t *p =  (uint32_t*)__get_PSP();
 #else
-            uint32_t *p = 0; // (uint32_t*)__get_MSP(); //FIXME
+            uint32_t msp;
+            asm volatile ("MRS %0, msp" : "=r" (msp) );
+            uint32_t *p = (uint32_t*)msp;
 #endif
             for (int i = 0; i < 8; i++)
             {
@@ -600,7 +602,9 @@ static void watchdog_callback(unsigned alarm_num)
 #ifdef __MBED__
             uint32_t *p =  (uint32_t*)__get_PSP();
 #else
-            uint32_t *p = 0; // -(uint32_t*)__get_MSP();
+            uint32_t msp;
+            asm volatile ("MRS %0, msp" : "=r" (msp) );
+            uint32_t *p = (uint32_t*)msp;
 #endif
             for (int i = 0; i < 8; i++)
             {
@@ -777,7 +781,7 @@ void platform_boot_to_main_firmware()
     // To ensure that the system state is reset properly, we perform
     // a SYSRESETREQ and jump straight from the reset vector to main application.
     g_bootloader_exit_req = &g_bootloader_exit_req;
-//    SCB->AIRCR = 0x05FA0004;
+    scb_hw->aircr = 0x05FA0004;
     while(1);
 }
 
@@ -790,7 +794,7 @@ void btldr_reset_handler()
         application_base = (uint32_t*)(XIP_BASE + PLATFORM_BOOTLOADER_SIZE);
     }
 
-//    SCB->VTOR = (uint32_t)application_base;
+    scb_hw->aircr = (uint32_t)application_base;
     __asm__(
         "msr msp, %0\n\t"
         "bx %1" : : "r" (application_base[0]),

--- a/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform.cpp
+++ b/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform.cpp
@@ -34,7 +34,9 @@
 #include "hardware/i2c.h"
 
 extern "C" {
+#ifdef ENABLE_NETWORK
 #include <pico/cyw43_arch.h>
+#endif
 
 const char *g_platform_name = PLATFORM_NAME;
 static bool g_scsi_initiator = false;
@@ -73,7 +75,7 @@ void mbed_error_hook(const mbed_error_ctx * error_context);
 /***************/
 
 // Helper function to configure whole GPIO in one line
-static void gpio_conf(uint gpio, enum gpio_function fn, bool pullup, bool pulldown, bool output, bool initial_state, bool fast_slew)
+static void gpio_conf(uint gpio, gpio_function_t fn, bool pullup, bool pulldown, bool output, bool initial_state, bool fast_slew)
 {
     gpio_put(gpio, initial_state);
     gpio_set_dir(gpio, output);
@@ -82,7 +84,7 @@ static void gpio_conf(uint gpio, enum gpio_function fn, bool pullup, bool pulldo
 
     if (fast_slew)
     {
-        padsbank0_hw->io[gpio] |= PADS_BANK0_GPIO0_SLEWFAST_BITS;
+        pads_bank0_hw->io[gpio] |= PADS_BANK0_GPIO0_SLEWFAST_BITS;
     }
 }
 
@@ -134,6 +136,7 @@ void platform_init()
     // Report platform and firmware version
     log("Platform: ", g_platform_name);
     log("FW Version: ", g_log_firmwareversion);
+    log("PicoSDK: ", PICO_SDK_VERSION_STRING);
 
     /* First configure the pins that affect external buffer directions.
      * RP2040 defaults to pulldowns, while these pins have external pull-ups.
@@ -173,8 +176,8 @@ void platform_init()
         gpio_conf(scsi_pins.IN_ATN,    GPIO_FUNC_SIO, false, false, false, false, false);
         delay(10); /// Settle time
         // Check option switches
-        bool optionS1 = !gpio_get(scsi_pins.IN_ATN);
-        bool optionS2 = !gpio_get(scsi_pins.IN_ACK);
+        [[maybe_unused]] bool optionS1 = !gpio_get(scsi_pins.IN_ATN);
+        [[maybe_unused]] bool optionS2 = !gpio_get(scsi_pins.IN_ACK);
 
         // Reset REQ to appropriate pin for older hardware
         scsi_pins.OUT_REQ = SCSI_OUT_REQ_BEFORE_2023_09a;
@@ -201,9 +204,9 @@ void platform_init()
     // Get flash chip size
     uint8_t cmd_read_jedec_id[4] = {0x9f, 0, 0, 0};
     uint8_t response_jedec[4] = {0};
-    __disable_irq();
+    uint32_t status = save_and_disable_interrupts();
     flash_do_cmd(cmd_read_jedec_id, response_jedec, 4);
-    __enable_irq();
+    restore_interrupts_from_disabled(status);
     g_flash_chip_size = (1 << response_jedec[3]);
     log("Flash chip size: ", (int)(g_flash_chip_size / 1024), " kB");
 
@@ -495,7 +498,7 @@ static void adc_poll()
     * If ADC sample reads are done, either via direct reading, FIFO, or DMA,
     * at the same time a SPI DMA write begins, it appears that the first
     * 16-bit word of the DMA data is lost. This causes the bitstream to glitch
-    * and audio to 'pop' noticably. For now, just disable ADC reads when audio
+    * and audio to 'pop' noticeably. For now, just disable ADC reads when audio
     * is playing.
     */
    if (audio_is_active()) return;
@@ -570,7 +573,7 @@ static void watchdog_callback(unsigned alarm_num)
 #ifdef __MBED__
             uint32_t *p =  (uint32_t*)__get_PSP();
 #else
-            uint32_t *p =  (uint32_t*)__get_MSP();
+            uint32_t *p = 0; // (uint32_t*)__get_MSP(); //FIXME
 #endif
             for (int i = 0; i < 8; i++)
             {
@@ -597,7 +600,7 @@ static void watchdog_callback(unsigned alarm_num)
 #ifdef __MBED__
             uint32_t *p =  (uint32_t*)__get_PSP();
 #else
-            uint32_t *p =  (uint32_t*)__get_MSP();
+            uint32_t *p = 0; // -(uint32_t*)__get_MSP();
 #endif
             for (int i = 0; i < 8; i++)
             {
@@ -627,7 +630,7 @@ void platform_reset_watchdog()
     if (!g_watchdog_initialized)
     {
         int alarm_num = -1;
-        for (int i = 0; i < NUM_TIMERS; i++)
+        for (int i = 0; i < NUM_GENERIC_TIMERS; i++)
         {
             if (!hardware_alarm_is_claimed(i))
             {
@@ -736,7 +739,7 @@ bool platform_rewrite_flash_page(uint32_t offset, uint8_t buffer[PLATFORM_FLASH_
     assert(offset >= PLATFORM_BOOTLOADER_SIZE);
 
     // Avoid any mbed timer interrupts triggering during the flashing.
-    __disable_irq();
+    uint32_t status = save_and_disable_interrupts();
 
     // For some reason any code executed after flashing crashes
     // unless we disable the XIP cache.
@@ -754,17 +757,17 @@ bool platform_rewrite_flash_page(uint32_t offset, uint8_t buffer[PLATFORM_FLASH_
     for (int i = 0; i < num_words; i++)
     {
         uint32_t expected = buf32[i];
-        uint32_t actual = *(volatile uint32_t*)(XIP_NOCACHE_BASE + offset + i * 4);
+        uint32_t actual = *(volatile uint32_t*)(XIP_SRAM_BASE + offset + i * 4);
 
         if (actual != expected)
         {
             log("Flash verify failed at offset ", offset + i * 4, " got ", actual, " expected ", expected);
-            __enable_irq();
+            restore_interrupts_from_disabled(status);
             return false;
         }
     }
 
-    __enable_irq();
+    restore_interrupts_from_disabled(status);
 
     return true;
 }
@@ -774,7 +777,7 @@ void platform_boot_to_main_firmware()
     // To ensure that the system state is reset properly, we perform
     // a SYSRESETREQ and jump straight from the reset vector to main application.
     g_bootloader_exit_req = &g_bootloader_exit_req;
-    SCB->AIRCR = 0x05FA0004;
+//    SCB->AIRCR = 0x05FA0004;
     while(1);
 }
 
@@ -787,7 +790,7 @@ void btldr_reset_handler()
         application_base = (uint32_t*)(XIP_BASE + PLATFORM_BOOTLOADER_SIZE);
     }
 
-    SCB->VTOR = (uint32_t)application_base;
+//    SCB->VTOR = (uint32_t)application_base;
     __asm__(
         "msr msp, %0\n\t"
         "bx %1" : : "r" (application_base[0]),
@@ -859,10 +862,10 @@ bool platform_write_romdrive(const uint8_t *data, uint32_t start, uint32_t count
     assert(start < platform_get_romdrive_maxsize());
     assert((count % PLATFORM_ROMDRIVE_PAGE_SIZE) == 0);
 
-    __disable_irq();
+    uint32_t status = save_and_disable_interrupts();
     flash_range_erase(start + ROMDRIVE_OFFSET, count);
     flash_range_program(start + ROMDRIVE_OFFSET, data, count);
-    __enable_irq();
+    restore_interrupts_from_disabled(status);
     return true;
 }
 

--- a/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform_gpio.h
+++ b/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform_gpio.h
@@ -3,7 +3,9 @@
 #pragma once
 
 #include <hardware/gpio.h>
+#ifdef ENABLE_NETWORK
 #include <pico/cyw43_arch.h>
+#endif
 
 // SCSI data input/output port.
 // The data bus uses external bidirectional buffer, with
@@ -56,8 +58,13 @@
 
 // Status LED pins
 #define LED_PIN      25
-#define LED_ON()     platform_network_supported() ? cyw43_gpio_set(&cyw43_state, 0, true) : sio_hw->gpio_set = 1 << LED_PIN
-#define LED_OFF()    platform_network_supported() ? cyw43_gpio_set(&cyw43_state, 0, false) : sio_hw->gpio_clr = 1 << LED_PIN
+#ifdef ENABLE_NETWORK
+    #define LED_ON()     platform_network_supported() ? cyw43_gpio_set(&cyw43_state, 0, true) : sio_hw->gpio_set = 1 << LED_PIN
+    #define LED_OFF()    platform_network_supported() ? cyw43_gpio_set(&cyw43_state, 0, false) : sio_hw->gpio_clr = 1 << LED_PIN
+#else
+    #define LED_ON()     sio_hw->gpio_set = 1 << LED_PIN
+    #define LED_OFF()    sio_hw->gpio_clr = 1 << LED_PIN
+#endif
 
 // SDIO and SPI block
 #define SD_SPI_SCK   10

--- a/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform_network.cpp
+++ b/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform_network.cpp
@@ -22,13 +22,13 @@
 
 extern "C" {
 
-#include <cyw43.h>
-#include <pico/cyw43_arch.h>
-
-#ifndef CYW43_IOCTL_GET_RSSI
-#define CYW43_IOCTL_GET_RSSI (0xfe)
+#ifdef ENABLE_NETWORK
+    #include <cyw43.h>
+    #include <pico/cyw43_arch.h>
+    #ifndef CYW43_IOCTL_GET_RSSI
+        #define CYW43_IOCTL_GET_RSSI (0xfe)
+    #endif
 #endif
-
 // A default DaynaPort-compatible MAC
 static const char defaultMAC[] = { 0x00, 0x80, 0x19, 0xc0, 0xff, 0xee };
 
@@ -45,6 +45,7 @@ bool platform_network_supported()
 #endif
 }
 
+#ifdef ENABLE_NETWORK
 int platform_network_init(char *mac)
 {
 	pico_unique_board_id_t board_id;
@@ -311,4 +312,5 @@ void cyw43_cb_tcpip_set_link_up(cyw43_t *self, int itf)
 		log_f("Successfully connected to Wi-Fi SSID \"%s\"", ssid);
 }
 
-}
+#endif
+} //extern c

--- a/lib/BlueSCSI_platform_RP2040/audio.cpp
+++ b/lib/BlueSCSI_platform_RP2040/audio.cpp
@@ -63,7 +63,7 @@ const uint8_t snd_parity[256] __attribute__((aligned(256), section(".scratch_y.s
  * receiver.
  * 
  * To facilitate fast lookups this table should be put in SRAM with low
- * contention, aligned to an apppropriate boundry.
+ * contention, aligned to an appropriate boundary.
  */
 const uint16_t biphase[256] __attribute__((aligned(512), section(".scratch_y.biphase"))) = {
     0xCCCC, 0xB333, 0xD333, 0xACCC, 0xCB33, 0xB4CC, 0xD4CC, 0xAB33,
@@ -306,7 +306,7 @@ static void snd_process_b() {
 }
 
 // Allows execution on Core1 via function pointers. Each function can take
-// no parameters and should return nothing, operating via side-effects only.
+// no parameters and should return nothing, operating via side effects only.
 static void core1_handler() {
     while (1) {
         void (*function)() = (void (*)()) multicore_fifo_pop_blocking();
@@ -357,6 +357,7 @@ bool audio_is_playing(uint8_t id) {
 void audio_setup() {
     // setup SPI to blast SP/DIF data over the TX pin
     spi_set_baudrate(AUDIO_SPI, 5644800); // will be slightly wrong, ~0.03% slow
+
     hw_write_masked(&spi_get_hw(AUDIO_SPI)->cr0,
             0x1F, // TI mode with 16 bits
             SPI_SSPCR0_DSS_BITS | SPI_SSPCR0_FRF_BITS);
@@ -497,7 +498,7 @@ bool audio_play(uint8_t owner, ImageBackingStore* img, uint64_t start, uint64_t 
     sfcnt = 0;
     invert = 0;
 
-    // setup the two DMA units to hand-off to each other
+    // setup the two DMA units to hand off to each other
     // to maintain a stable bitstream these need to run without interruption
 	snd_dma_a_cfg = dma_channel_get_default_config(SOUND_DMA_CHA);
 	channel_config_set_transfer_data_size(&snd_dma_a_cfg, DMA_SIZE_16);

--- a/lib/BlueSCSI_platform_RP2040/rp2040_sdio.cpp
+++ b/lib/BlueSCSI_platform_RP2040/rp2040_sdio.cpp
@@ -816,7 +816,7 @@ static void rp2040_sdio_tx_irq()
 // Check if transmission is complete
 sdio_status_t rp2040_sdio_tx_poll(uint32_t *bytes_complete)
 {
-//    if (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) // FIXME:
+    if (scb_hw->icsr & (0x1FFUL))
     {
         // Verify that IRQ handler gets called even if we are in hardfault handler
         rp2040_sdio_tx_irq();

--- a/lib/BlueSCSI_platform_RP2040/rp2040_sdio.cpp
+++ b/lib/BlueSCSI_platform_RP2040/rp2040_sdio.cpp
@@ -18,6 +18,11 @@
 #include <BlueSCSI_platform.h>
 #include <BlueSCSI_log.h>
 
+//#ifndef ENABLE_NETWORK
+//#include <core_cm33.h>
+// #include <core_cm0plus.h>
+//#endif
+
 #define SDIO_PIO pio1
 #define SDIO_CMD_SM 0
 #define SDIO_DATA_SM 1
@@ -811,7 +816,7 @@ static void rp2040_sdio_tx_irq()
 // Check if transmission is complete
 sdio_status_t rp2040_sdio_tx_poll(uint32_t *bytes_complete)
 {
-    if (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk)
+//    if (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) // FIXME:
     {
         // Verify that IRQ handler gets called even if we are in hardfault handler
         rp2040_sdio_tx_irq();

--- a/lib/BlueSCSI_platform_RP2040/scsi_accel.pio
+++ b/lib/BlueSCSI_platform_RP2040/scsi_accel.pio
@@ -13,9 +13,12 @@
 
 ; Delay from data setup to REQ assertion.
 ; deskew delay + cable skew delay = 55 ns minimum
+;  Pico 1
 ; One clock cycle is 8 ns => delay 7 clocks
-.define REQ_DLY 7
-
+; .define REQ_DLY 7
+;  Pico 2
+; One clock cycle is 6.67 ns (150MHz) => delay 8.25 clocks or 9 clocks
+.define REQ_DLY 9
 ; Adds parity to data that is to be written to SCSI
 ; This works by generating addresses for DMA to fetch data from.
 ; Register X should be initialized to the base address of the lookup table.

--- a/lib/BlueSCSI_platform_RP2040/scsi_accel.pio.h
+++ b/lib/BlueSCSI_platform_RP2040/scsi_accel.pio.h
@@ -49,7 +49,7 @@ static const uint16_t scsi_accel_async_write_program_instructions[] = {
             //     .wrap_target
     0x90e0, //  0: pull   ifempty block   side 1     
     0x7009, //  1: out    pins, 9         side 1     
-    0x7577, //  2: out    null, 23        side 1 [5] 
+    0x7777, //  2: out    null, 23        side 1 [7]
     0x309a, //  3: wait   1 gpio, 26      side 1     
     0x201a, //  4: wait   0 gpio, 26      side 0     
             //     .wrap

--- a/lib/BlueSCSI_platform_RP2040/scsi_accel_rp2040.cpp
+++ b/lib/BlueSCSI_platform_RP2040/scsi_accel_rp2040.cpp
@@ -1051,15 +1051,24 @@ bool scsi_accel_rp2040_setSyncMode(int syncOffset, int syncPeriod)
             // delay1: Delay from REQ assert to REQ deassert
             // delay2: Delay from REQ deassert to data write
             int delay0, delay1, delay2;
+#ifdef BLUESCSI_PICO2
+            int totalDelay = syncPeriod * 100 / 667 + 1;    //The +1 is empyrical to get the right transfer speed
+#else
             int totalDelay = syncPeriod * 4 / 8;
+#endif
 
             if (syncPeriod <= 25)
             {
                 // Fast SCSI timing: 30 ns assertion period, 25 ns skew delay
                 // The hardware rise and fall time require some extra delay,
                 // the values below are tuned based on oscilloscope measurements.
+#ifdef BLUESCSI_PICO2
+                delay0 = 4;
+                delay1 = 6;
+#else
                 delay0 = 3;
                 delay1 = 5;
+#endif
                 delay2 = totalDelay - delay0 - delay1 - 3;
                 if (delay2 < 0) delay2 = 0;
                 if (delay2 > 15) delay2 = 15;
@@ -1067,8 +1076,13 @@ bool scsi_accel_rp2040_setSyncMode(int syncOffset, int syncPeriod)
             else
             {
                 // Slow SCSI timing: 90 ns assertion period, 55 ns skew delay
+#ifdef BLUESCSI_PICO2
+                delay0 = 7;
+                delay1 = 14;
+#else
                 delay0 = 6;
                 delay1 = 12;
+#endif
                 delay2 = totalDelay - delay0 - delay1 - 3;
                 if (delay2 < 0) delay2 = 0;
                 if (delay2 > 15) delay2 = 15;

--- a/lib/BlueSCSI_platform_RP2040/scsi_accel_rp2040.cpp
+++ b/lib/BlueSCSI_platform_RP2040/scsi_accel_rp2040.cpp
@@ -204,7 +204,7 @@ void scsi_accel_rp2040_startWrite(const uint8_t* data, uint32_t count, volatile 
     // Any read requests should be matched with a stopRead()
     assert(g_scsi_dma_state != SCSIDMA_READ && g_scsi_dma_state != SCSIDMA_READ_DONE);
 
-    __disable_irq();
+    uint32_t status = save_and_disable_interrupts();
     if (g_scsi_dma_state == SCSIDMA_WRITE)
     {
         if (!g_scsi_dma.next_app_buf && data == g_scsi_dma.app_buf + g_scsi_dma.app_bytes)
@@ -227,7 +227,7 @@ void scsi_accel_rp2040_startWrite(const uint8_t* data, uint32_t count, volatile 
             count = 0;
         }
     }
-    __enable_irq();
+    restore_interrupts_from_disabled(status);
 
     // Check if the request was combined
     if (count == 0) return;
@@ -326,7 +326,7 @@ bool scsi_accel_rp2040_isWriteFinished(const uint8_t* data)
 
     // Check if this data item is still in queue.
     bool finished = true;
-    __disable_irq();
+    uint32_t status = save_and_disable_interrupts();
     if (data >= g_scsi_dma.app_buf &&
         data < g_scsi_dma.app_buf + g_scsi_dma.app_bytes &&
         (uint32_t)data >= dma_hw->ch[SCSI_DMA_CH_A].al1_read_addr)
@@ -338,7 +338,7 @@ bool scsi_accel_rp2040_isWriteFinished(const uint8_t* data)
     {
         finished = false; // In queued transfer
     }
-    __enable_irq();
+    restore_interrupts_from_disabled(status);
 
     return finished;
 }
@@ -589,7 +589,7 @@ void scsi_accel_rp2040_startRead(uint8_t *data, uint32_t count, int *parityError
     // Any write requests should be matched with a stopWrite()
     assert(g_scsi_dma_state != SCSIDMA_WRITE && g_scsi_dma_state != SCSIDMA_WRITE_DONE);
 
-    __disable_irq();
+    uint32_t status = save_and_disable_interrupts();
     if (g_scsi_dma_state == SCSIDMA_READ)
     {
         if (!g_scsi_dma.next_app_buf && data == g_scsi_dma.app_buf + g_scsi_dma.app_bytes)
@@ -612,7 +612,7 @@ void scsi_accel_rp2040_startRead(uint8_t *data, uint32_t count, int *parityError
             count = 0;
         }
     }
-    __enable_irq();
+    restore_interrupts_from_disabled(status);
 
     // Check if the request was combined
     if (count == 0) return;
@@ -658,7 +658,7 @@ bool scsi_accel_rp2040_isReadFinished(const uint8_t* data)
 
     // Check if this data item is still in queue.
     bool finished = true;
-    __disable_irq();
+    uint32_t status = save_and_disable_interrupts();
     if (data >= g_scsi_dma.app_buf &&
         data < g_scsi_dma.app_buf + g_scsi_dma.app_bytes &&
         (uint32_t)data >= dma_hw->ch[SCSI_DMA_CH_A].write_addr)
@@ -670,7 +670,7 @@ bool scsi_accel_rp2040_isReadFinished(const uint8_t* data)
     {
         finished = false; // In queued transfer
     }
-    __enable_irq();
+    restore_interrupts_from_disabled(status);
 
     return finished;
 }

--- a/lib/SCSI2SD/src/firmware/mode.c
+++ b/lib/SCSI2SD/src/firmware/mode.c
@@ -261,7 +261,7 @@ static const uint8_t IomegaZip100VendorPage[] =
 0x5c, 0xf, 0xff, 0xf
 };
 
-static const uint8_t IomegaZip250VendorPage[] =
+__attribute__((unused)) static const uint8_t IomegaZip250VendorPage[] =
 {
 0x2f, // Page Code
 4, // Page Length

--- a/lib/SCSI2SD/src/firmware/network.c
+++ b/lib/SCSI2SD/src/firmware/network.c
@@ -14,6 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#ifdef ENABLE_NETWORK
 #include <string.h>
 
 #include "scsi.h"
@@ -528,3 +529,4 @@ int scsiNetworkPurge(void)
 
 	return sent;
 }
+#endif

--- a/lib/SCSI2SD/src/firmware/scsi.c
+++ b/lib/SCSI2SD/src/firmware/scsi.c
@@ -621,10 +621,13 @@ static void process_Command()
 	}
 	// Handle odd device types first that may override basic read and
 	// write commands. Will fall-through to generic disk handling.
-	else if (((cfg->deviceType == S2S_CFG_OPTICAL) && scsiCDRomCommand()) ||
-		((cfg->deviceType == S2S_CFG_SEQUENTIAL) && scsiTapeCommand()) ||
-		((cfg->deviceType == S2S_CFG_MO) && scsiMOCommand()) ||
-		((cfg->deviceType == S2S_CFG_NETWORK && scsiNetworkCommand())))
+	else if (((cfg->deviceType == S2S_CFG_OPTICAL) && scsiCDRomCommand())
+		|| ((cfg->deviceType == S2S_CFG_SEQUENTIAL) && scsiTapeCommand())
+		|| ((cfg->deviceType == S2S_CFG_MO) && scsiMOCommand())
+#ifdef ENABLE_NETWORK
+		|| ((cfg->deviceType == S2S_CFG_NETWORK && scsiNetworkCommand()))
+#endif
+        )
 	{
 		// Already handled.
 	}

--- a/platformio.ini
+++ b/platformio.ini
@@ -51,8 +51,9 @@ build_flags =
 board = rpipico2
 ;board_build.mcu = rp2350-riscv
 extends = env:BlueSCSI_Pico
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git#2d445020acf8b792768a5fa5ba1870ac9607c11c
 platform_packages =
-    framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#f49d058477ac8dacd802ff65b528cf755b6de191
+    framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#fdd755715655bd9ddd6a3d7d6653be5a177c8e6b
 ;board_build.f_cpu = 200000000L
 ; Pico2 does not have a wifi version yet.
 build_unflags =

--- a/platformio.ini
+++ b/platformio.ini
@@ -51,13 +51,15 @@ build_flags =
 board = rpipico2
 ;board_build.mcu = rp2350-riscv
 extends = env:BlueSCSI_Pico
+platform_packages =
+    framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#f49d058477ac8dacd802ff65b528cf755b6de191
 ;board_build.f_cpu = 200000000L
-
 ; Pico2 does not have a wifi version yet.
 build_unflags =
     -DENABLE_NETWORK
 build_flags =
     ${env:BlueSCSI_Pico.build_flags}
+    -DBLUESCSI_PICO2=1
 ;    -DPICO_COPY_TO_RAM=1
 
 ; Experimental Audio build

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@ default_envs = BlueSCSI_Pico
 
 ; BlueSCSI RP2040 hardware platform, based on the Raspberry Pi foundation RP2040 microcontroller
 [env:BlueSCSI_Pico]
-platform = https://github.com/maxgerhardt/platform-raspberrypi.git#rp2350_picosdk
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git#5e87ae34ca025274df25b3303e9e9cb6c120123c
 platform_packages = platformio/toolchain-gccarmnoneeabi@1.120301.0
     framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#master
 ;board_build.f_cpu = 250000000L
@@ -45,10 +45,11 @@ build_flags =
     -DUSE_ARDUINO=1
     -DPICO_DEFAULT_I2C_SDA_PIN=16
     -DPICO_DEFAULT_I2C_SCL_PIN=17
-    -DENABLE_NETWORK=1
+    -DENABLE_NETWORK
 
 [env:BlueSCSI_Pico2]
 board = rpipico2
+;board_build.mcu = rp2350-riscv
 extends = env:BlueSCSI_Pico
 ;board_build.f_cpu = 200000000L
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,9 +12,10 @@ default_envs = BlueSCSI_Pico
 
 ; BlueSCSI RP2040 hardware platform, based on the Raspberry Pi foundation RP2040 microcontroller
 [env:BlueSCSI_Pico]
-platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git#rp2350_picosdk
 platform_packages = platformio/toolchain-gccarmnoneeabi@1.120301.0
-    framework-arduinopico@https://github.com/BlueSCSI/arduino-pico-internal.git#e139b9c7816602597f473b3231032cca5d71a48a
+    framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#master
+;board_build.f_cpu = 250000000L
 framework = arduino
 board = rpipicow
 board_build.core = earlephilhower
@@ -44,9 +45,19 @@ build_flags =
     -DUSE_ARDUINO=1
     -DPICO_DEFAULT_I2C_SDA_PIN=16
     -DPICO_DEFAULT_I2C_SCL_PIN=17
-    ; -DLOGBUFSIZE=8192
-    ; -DPREFETCH_BUFFER_SIZE=6144
-    ; -DSCSI2SD_BUFFER_SIZE=57344
+    -DENABLE_NETWORK=1
+
+[env:BlueSCSI_Pico2]
+board = rpipico2
+extends = env:BlueSCSI_Pico
+;board_build.f_cpu = 200000000L
+
+; Pico2 does not have a wifi version yet.
+build_unflags =
+    -DENABLE_NETWORK
+build_flags =
+    ${env:BlueSCSI_Pico.build_flags}
+;    -DPICO_COPY_TO_RAM=1
 
 ; Experimental Audio build
 ; Requires separate hardware and overclock.

--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -548,11 +548,13 @@ static void reinitSCSI()
   scsiDiskInit();
   scsiInit();
 
+#ifdef ENABLE_NETWORK
   if (scsiDiskCheckAnyNetworkDevicesConfigured())
   {
     platform_network_init(scsiDev.boardCfg.wifiMACAddress);
     platform_network_wifi_join(scsiDev.boardCfg.wifiSSID, scsiDev.boardCfg.wifiPassword);
   }
+#endif
 }
 
 extern "C" void bluescsi_setup(void)
@@ -679,7 +681,9 @@ extern "C" void bluescsi_main_loop(void)
   platform_reset_watchdog();
   platform_poll();
   diskEjectButtonUpdate(true);
+#ifdef ENABLE_NETWORK
   platform_network_poll();
+#endif
   
 #ifdef PLATFORM_HAS_INITIATOR_MODE
   if (unlikely(platform_is_initiator_mode_enabled()))

--- a/src/BlueSCSI_config.h
+++ b/src/BlueSCSI_config.h
@@ -59,7 +59,7 @@
 #define DRIVEINFO_TAPE      {"BlueSCSI", "TAPE",      PLATFORM_REVISION, ""}
 
 // Default SCSI drive information when Apple quirks are enabled
-#define APPLE_DRIVEINFO_FIXED     {"QUANTUM",  "BlueSCSI Pico",   "1.0",  ""}
+#define APPLE_DRIVEINFO_FIXED     {"QUANTUM",  "BlueSCSI Pico2",   "1.0",  ""}
 #define APPLE_DRIVEINFO_REMOVABLE {"IOMEGA",   "BETA230",         "2.02", ""}
 #define APPLE_DRIVEINFO_OPTICAL   {"BlueSCSI", "CD-ROM CDU-55S",  "1.9a", ""}
 #define APPLE_DRIVEINFO_FLOPPY    {"TEAC",     "FD235HS",         "1.44", ""}


### PR DESCRIPTION
Test on _any_ version of BlueSCSI hardware with a Pico 2.

Observations/Notes:
 - ~10%+ write improvement
 - Pico 2 has no Wi-Fi version yet

**BlueSCSI v2 Pico 1 vs Pico 2 Initial Tests**

| Machine | Model | Read | Write | Test |
| - | - | - | - | - |
| 6115-Apple | Pico2 | 4304 | 3921 | SDP4 |
| 6115-Apple | Pico1-9/15/24 | 4459 | 3777 | SDP4 |
| 9600-Apple | Pico2 | 3840 | 3525 | SDP4 |
| 9600-Apple | Pico1-9/15/24 | 3840 | 3487 | SDP4 |
| 9600-FWB | Pico2 | 8225 | 5615 | SDP4 |
| 9600-FWB | Pico1-9/15/24 | 8225 | 5232 | SDP4 |
| 9600-FWB | Pico2 | 8618 | 7054 | FWBBench |
| 9600-FWB | Pico1-9/15/24 | 8618 | 6374 | FWBBench |

If you want to try it out grab the bin's from here:

[BlueSCSI-Pico2-58226df.uf2.zip](https://github.com/user-attachments/files/17379056/BlueSCSI-Pico2-58226df.uf2.zip)

Devs: When building use the BlueSCSI_Pico2 Platform.io profile.




