### PR TITLE
Setting To Ignore Parity For Initiator Mode Data Transfers

### DIFF
--- a/lib/BlueSCSI_platform_RP2040/scsiHostPhy.h
+++ b/lib/BlueSCSI_platform_RP2040/scsiHostPhy.h
@@ -30,3 +30,5 @@ uint32_t scsiHostRead(uint8_t *data, uint32_t count);
 
 // Release all bus signals
 void scsiHostPhyRelease();
+
+void setInitiatorModeParityCheck(bool checkParity);

--- a/lib/BlueSCSI_platform_RP2040/scsi_accel_host.cpp
+++ b/lib/BlueSCSI_platform_RP2040/scsi_accel_host.cpp
@@ -1,5 +1,6 @@
 // Accelerated SCSI subroutines for SCSI initiator/host side communication
 // Copyright (c) 2022 Rabbit Hole Computing™
+// Copyright (c) 2024 Tech by Androda, LLC
 
 #include "scsi_accel_host.h"
 #include "BlueSCSI_platform.h"
@@ -65,7 +66,7 @@ static void scsi_accel_host_config_gpio()
     }
 }
 
-uint32_t scsi_accel_host_read(uint8_t *buf, uint32_t count, int *parityError, volatile int *resetFlag)
+uint32_t scsi_accel_host_read(uint8_t *buf, uint32_t count, int *parityError, uint32_t *parityResult, volatile int *resetFlag)
 {
     // Currently this method just reads from the PIO RX fifo directly in software loop.
     // The SD card access is parallelized using DMA, so there is limited benefit from using DMA here.
@@ -117,8 +118,8 @@ uint32_t scsi_accel_host_read(uint8_t *buf, uint32_t count, int *parityError, vo
     uint8_t byte1 = ~(paritycheck >> 16);
     if (paritycheck != ((g_scsi_parity_lookup[byte1] << 16) | g_scsi_parity_lookup[byte0]))
     {
-        log("Parity error in scsi_accel_host_read(): ", paritycheck);
         *parityError = 1;
+        *parityResult = paritycheck;
     }
 
     g_scsi_host_state = SCSIHOST_IDLE;

--- a/lib/BlueSCSI_platform_RP2040/scsi_accel_host.h
+++ b/lib/BlueSCSI_platform_RP2040/scsi_accel_host.h
@@ -8,4 +8,4 @@ void scsi_accel_host_init();
 
 // Read data from SCSI bus.
 // Number of bytes to read must be divisible by two.
-uint32_t scsi_accel_host_read(uint8_t *buf, uint32_t count, int *parityError, volatile int *resetFlag);
+uint32_t scsi_accel_host_read(uint8_t *buf, uint32_t count, int *parityError, uint32_t *parityResult, volatile int *resetFlag);

--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -610,6 +610,11 @@ extern "C" void bluescsi_setup(void)
     if (ini_getbool("SCSI", "InitiatorMode", false, CONFIGFILE))
     {
       platform_enable_initiator_mode();
+      if (! ini_getbool("SCSI", "InitiatorParity", true, CONFIGFILE))
+      {
+        log("Initiator Mode Skipping Parity Check.");
+        setInitiatorModeParityCheck(false);
+      }
     }
     if (SD.clusterCount() == 0)
     {


### PR DESCRIPTION
Adding a new ini file option to ignore parity errors in initiator mode.  Very old SCSI 1 drives, such as those using SCSI to Winchester adapters, might not support parity at all.   This causes an incredibly slow data backup because a warning is written to the log for every block of data transferred.

This is how the INI file should be structured to disable initiator mode parity checking:
```
[SCSI]
InitiatorMode=1
InitiatorParity=0
```