### PR TITLE
GPIO Drive Strength Config for SDIO Pins

### DIFF
--- a/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform.h
+++ b/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform.h
@@ -94,6 +94,7 @@ bool is202309a();
 typedef void (*sd_callback_t)(uint32_t bytes_complete);
 void platform_set_sd_callback(sd_callback_t func, const uint8_t *buffer);
 void add_extra_sdio_delay(uint16_t additional_delay);
+void set_sdio_drive_strength(long ini_setting);
 
 // Reprogram firmware in main program area.
 #ifndef RP2040_DISABLE_BOOTLOADER

--- a/lib/BlueSCSI_platform_RP2040/sd_card_sdio.cpp
+++ b/lib/BlueSCSI_platform_RP2040/sd_card_sdio.cpp
@@ -49,6 +49,31 @@ void add_extra_sdio_delay(uint16_t additional_delay) {
     rp2040_sdio_delay_increment(additional_delay);
 }
 
+void set_sdio_drive_strength(long ini_setting) {
+    gpio_drive_strength drive_strength;
+    switch (ini_setting) {
+      case 1:
+        drive_strength = GPIO_DRIVE_STRENGTH_2MA;
+        break;
+      default:
+      case 2:
+        drive_strength = GPIO_DRIVE_STRENGTH_4MA;
+        break;
+      case 3:
+        drive_strength = GPIO_DRIVE_STRENGTH_8MA;
+        break;
+      case 4:
+        drive_strength = GPIO_DRIVE_STRENGTH_12MA;
+        break;
+    }
+    gpio_set_drive_strength(SDIO_CMD, drive_strength);
+    gpio_set_drive_strength(SDIO_CLK, drive_strength);
+    gpio_set_drive_strength(SDIO_D0, drive_strength);
+    gpio_set_drive_strength(SDIO_D1, drive_strength);
+    gpio_set_drive_strength(SDIO_D2, drive_strength);
+    gpio_set_drive_strength(SDIO_D3, drive_strength);
+}
+
 static sd_callback_t get_stream_callback(const uint8_t *buf, uint32_t count, const char *accesstype, uint32_t sector)
 {
     m_stream_count_start = m_stream_count;

--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -571,6 +571,18 @@ void check_and_apply_sdio_delay() {
   }
 }
 
+void check_and_apply_sdio_drive_strength() {
+  long sdio_drive_strength = ini_getl("SDIO", "GPIODriveStrength", 0, CONFIGFILE);
+  if (sdio_drive_strength) {
+    if (sdio_drive_strength < 1 || sdio_drive_strength > 4) {
+      log("---- WARNING: GPIODriveStrength setting invalid (Expected 1 - 4), defaulting to setting 2.");
+      return;
+    }
+    log("INFO: Setting SDIO GPIO drive strength level ", (uint16_t)sdio_drive_strength, ".");
+    set_sdio_drive_strength(sdio_drive_strength);
+  }
+}
+
 extern "C" void bluescsi_setup(void)
 {
   pio_clear_instruction_memory(pio0);
@@ -621,6 +633,7 @@ extern "C" void bluescsi_setup(void)
       log("SD card without filesystem!");
     }
     check_and_apply_sdio_delay();
+    check_and_apply_sdio_drive_strength();
 
     print_sd_info();
   
@@ -759,6 +772,7 @@ extern "C" void bluescsi_main_loop(void)
       {
         log("SD card reinit succeeded");
         check_and_apply_sdio_delay();
+        check_and_apply_sdio_drive_strength();
         print_sd_info();
 
         reinitSCSI();


### PR DESCRIPTION
Allows configuration of the SDIO pins' drive strength as another potential mitigation against electrically noisy environments.

The GPIODriveStrength config param under [SDIO] can be set to the values 1 through 4, with a default value of 2.

The mapping is as follows:
GPIODriveStrength=1: 2mA drive
GPIODriveStrength=2: 4mA drive (Pico SDK defaults here)
GPIODriveStrength=3: 8mA drive
GPIODriveStrength=4: 12mA drive

I have tested all of these settings on my 7300 and they all passed benchmarks and copied files without error.

Example INI config:
```
[SDIO]
GPIODriveStrength=2
```