### PR TITLE
Pico 2 & Pico 2-W Support with universal UF2

### DIFF
--- a/.github/workflows/firmware_build.yml
+++ b/.github/workflows/firmware_build.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build firmware
         run: |
           cd BlueSCSI
-          pio run -v -e BlueSCSI_Pico
+          pio run -v -e BlueSCSI_Pico -e BlueSCSI_Pico2
 
       - name: Rename firmware files
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 .vscode/extensions.json
 cc-nc-hardware/*/*-backups/
 .idea/
+distrib/

--- a/boards/rpipico2w.json
+++ b/boards/rpipico2w.json
@@ -1,0 +1,55 @@
+{
+  "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "none.S",
+        "usb_vid": "0x2E8A",
+        "usb_pid": "0xF00F"
+      }
+    },
+    "core": "earlephilhower",
+    "cpu": "cortex-m33",
+    "extra_flags": "-DARDUINO_RASPBERRY_PI_PICO_2W -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250  -DPICO_CYW43_SUPPORTED=1 -DCYW43_PIN_WL_DYNAMIC=1",
+    "f_cpu": "150000000L",
+    "hwids": [
+      [
+        "0x2E8A",
+        "0x00C0"
+      ],
+      [
+        "0x2E8A",
+        "0xF00F"
+      ]
+    ],
+    "mcu": "rp2350",
+    "variant": "rpipico2w"
+  },
+  "debug": {
+    "jlink_device": "RP2350_0",
+    "openocd_target": "rp2350.cfg",
+    "svd_path": "rp2350.svd"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "Pico 2W",
+  "upload": {
+    "maximum_ram_size": 524288,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "native_usb": true,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": false,
+    "protocol": "picotool",
+    "protocols": [
+      "blackmagic",
+      "cmsis-dap",
+      "jlink",
+      "raspberrypi-swd",
+      "picotool",
+      "picoprobe"
+    ]
+  },
+  "url": "https://www.raspberrypi.org/products/raspberry-pi-pico/",
+  "vendor": "Raspberry Pi"
+}

--- a/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform.cpp
+++ b/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform.cpp
@@ -85,6 +85,31 @@ static void gpio_conf(uint gpio, gpio_function_t fn, bool pullup, bool pulldown,
     }
 }
 
+# ifndef PICO_RP2040
+/**
+ * This is a workaround until arduino framework can be updated to handle all 4 variations of
+ * Pico1/1w/2/2w. In testing this works on all for BlueSCSI.
+ * Tracking here https://github.com/earlephilhower/arduino-pico/issues/2671
+ */
+static void CheckPicoW() {
+    extern bool __isPicoW;
+    adc_init();
+    auto dir = gpio_get_dir(CYW43_PIN_WL_CLOCK);
+    auto fnc = gpio_get_function(CYW43_PIN_WL_CLOCK);
+    adc_gpio_init(CYW43_PIN_WL_CLOCK);
+    adc_select_input(3);
+    auto adc29 = adc_read();
+    gpio_set_function(CYW43_PIN_WL_CLOCK, fnc);
+    gpio_set_dir(CYW43_PIN_WL_CLOCK, dir);
+    debuglog("CheckPicoW adc29: %d", adc29);
+    if (adc29 < 200) {
+        __isPicoW = true; // PicoW || Pico2W
+    } else {
+        __isPicoW = false;
+    }
+}
+#endif
+
 #ifdef ENABLE_AUDIO_OUTPUT
 // Increases clk_sys and clk_peri to 135.428571MHz at runtime to support
 // division to audio output rates. Invoke before anything is using clk_peri
@@ -219,6 +244,10 @@ void platform_init()
     gpio_conf(SD_SPI_CS,      GPIO_FUNC_SIO, true, false, true,  true, true);
     gpio_conf(SDIO_D1,        GPIO_FUNC_SIO, true, false, false, true, true);
     gpio_conf(SDIO_D2,        GPIO_FUNC_SIO, true, false, false, true, true);
+
+# ifndef PICO_RP2040
+    CheckPicoW(); // Override default Wi-Fi check for the Pico2 line.
+# endif
 
     if (!platform_network_supported()) {
         // LED pin

--- a/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform_network.cpp
+++ b/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform_network.cpp
@@ -37,6 +37,8 @@ static bool network_in_use = false;
 
 bool __not_in_flash_func(platform_network_supported)()
 {
+	// FIXME: This method currently incorrectly returns true on the Pico2 (non-wifi)
+	//   Track here: https://github.com/earlephilhower/arduino-pico/issues/2671
 	return rp2040.isPicoW();
 }
 

--- a/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform_network.cpp
+++ b/lib/BlueSCSI_platform_RP2040/BlueSCSI_platform_network.cpp
@@ -16,7 +16,6 @@
 
 #include "BlueSCSI_platform.h"
 #include "BlueSCSI_log.h"
-#include "BlueSCSI_config.h"
 #include <scsi.h>
 #include <network.h>
 
@@ -37,9 +36,8 @@ static bool network_in_use = false;
 
 bool __not_in_flash_func(platform_network_supported)()
 {
-	// FIXME: This method currently incorrectly returns true on the Pico2 (non-wifi)
-	//   Track here: https://github.com/earlephilhower/arduino-pico/issues/2671
-	return rp2040.isPicoW();
+	extern bool __isPicoW;
+	return __isPicoW;
 }
 
 #ifdef BLUESCSI_NETWORK

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@ default_envs = BlueSCSI_Pico
 
 ; BlueSCSI RP2040 hardware platform, based on the Raspberry Pi foundation RP2040 microcontroller
 [env:BlueSCSI_Pico]
-platform = https://github.com/maxgerhardt/platform-raspberrypi.git#2d445020acf8b792768a5fa5ba1870ac9607c11c
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git#19e30129fb1428b823be585c787dcb4ac0d9014c
 platform_packages =
     framework-arduinopico@https://github.com/BlueSCSI/arduino-pico-internal.git#v4.1.1-DaynaPORT
 framework = arduino
@@ -47,6 +47,21 @@ build_flags =
     -DBLUESCSI_NETWORK=1
 ; Arduino's default USB task/irq is conflicting with WiFi somehow
     -DUSE_TINYUSB
+; build flags mirroring the framework-arduinopico#v4.1.1-DaynaPORT static library build
+    -DPICO_CYW43_ARCH_POLL=1
+    -DCYW43_LWIP=0
+    -DCYW43_USE_OTP_MAC=0
+
+[env:BlueSCSI_Pico2]
+board = rpipico2w
+extends = env:BlueSCSI_Pico
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git#19e30129fb1428b823be585c787dcb4ac0d9014c
+platform_packages =
+    framework-arduinopico@https://github.com/BlueSCSI/arduino-pico-internal.git#v4.3.0-DaynaPORT
+build_flags =
+    ${env:BlueSCSI_Pico.build_flags}
+    -DCYW43_PIO_CLOCK_DIV_DYNAMIC=1
+    -DBLUESCSI_PICO2=1
 ; build flags mirroring the framework-arduinopico#v4.1.1-DaynaPORT static library build
     -DPICO_CYW43_ARCH_POLL=1
     -DCYW43_LWIP=0

--- a/utils/rename_binaries.sh
+++ b/utils/rename_binaries.sh
@@ -1,16 +1,19 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script renames the built binaries according to version
 # number and platform.
-
+set -e
+set -x
 mkdir -p distrib
 
 DATE=$(date +%Y-%m-%d)
 VERSION=$(git describe --always)
 
-for file in $(ls .pio/build/*/*.bin .pio/build/*/*.elf .pio/build/*/*.uf2)
+for file in .pio/build/*/*.bin .pio/build/*/*.elf .pio/build/*/*.uf2
 do
-    NEWNAME=$(echo $file | sed 's|.pio/build/\([^/]*\)/\(.*\)\.\(.*\)|\1_'$DATE'_'$VERSION'.\3|')
-    echo $file to distrib/$NEWNAME
-    cp $file distrib/$NEWNAME
+    NEWNAME=$(echo "$file" | sed 's|.pio/build/\([^/]*\)/\(.*\)\.\(.*\)|\1_'$DATE'_'$VERSION'.\3|')
+    echo "$file" to distrib/"$NEWNAME"
+    cp "$file" distrib/"$NEWNAME"
 done
+
+cat distrib/*.uf2 > distrib/BlueSCSI_Universal_"$DATE"_"$VERSION".uf2


### PR DESCRIPTION
Replaces https://github.com/BlueSCSI/BlueSCSI-v2/pull/198

Most of the framework updates were already merged in to main since working on this.

The runtime Pico (1/2) wifi check is currently not working on the Pico2 - Tracking https://github.com/earlephilhower/arduino-pico/issues/2671 - but added a work around.

You can flash the - `BlueSCSI_Universal_*.uf2` to a Pico 1, Pico 1W, Pico 2, or Pico 2W - no need to browse through 100 different firmware to choose.

Observations/Notes:
 - ~10%+ write improvement

**BlueSCSI v2 Pico 1 vs Pico 2 Initial Tests**

| Machine | Model | Read | Write | Test |
| - | - | - | - | - |
| 6115-Apple | Pico2 | 4304 | 3921 | SDP4 |
| 6115-Apple | Pico1-9/15/24 | 4459 | 3777 | SDP4 |
| 9600-Apple | Pico2 | 3840 | 3525 | SDP4 |
| 9600-Apple | Pico1-9/15/24 | 3840 | 3487 | SDP4 |
| 9600-FWB | Pico2 | 8225 | 5615 | SDP4 |
| 9600-FWB | Pico1-9/15/24 | 8225 | 5232 | SDP4 |
| 9600-FWB | Pico2 | 8618 | 7054 | FWBBench |
| 9600-FWB | Pico1-9/15/24 | 8618 | 6374 | FWBBench |

Devs: When building use the `BlueSCSI_Pico2` Platform.io profile.