### PR TITLE
Fix wrong use of sizeof() on char*

### DIFF
--- a/src/BlueSCSI_config.cpp
+++ b/src/BlueSCSI_config.cpp
@@ -40,27 +40,26 @@ int getBlockSize(char *filename, int scsiId, int default_size)
   return default_size;
 }
 
-int getImgDir(int scsiId, char* dirname)
+int getImgDir(int scsiId, char* dirname, size_t dname_len)
 {
   char section[6] = "SCSI0";
   section[4] = '0' + scsiId;
 
   char key[] = "ImgDir";
-  int dirlen = ini_gets(section, key, "", dirname, sizeof(dirname), CONFIGFILE);
+  int dirlen = ini_gets(section, key, "", dirname, dname_len, CONFIGFILE);
   return dirlen;
 }
 
 
-int getImg(int scsiId, int img_index, char* filename)
+int getImg(int scsiId, int img_index, char* filename, size_t fname_len)
 {
   char section[6] = "SCSI0";
   section[4] = '0' + scsiId;
 
   char key[] = "IMG0";
   key[3] = '0' + img_index;
-
-  int dirlen = ini_gets(section, key, "", filename, sizeof(filename), CONFIGFILE);
-  return dirlen;
+  int fnlen = ini_gets(section, key, "", filename, fname_len, CONFIGFILE);
+  return fnlen;
 }
 
 int getToolBoxSharedDir(char * dir_name)

--- a/src/BlueSCSI_config.h
+++ b/src/BlueSCSI_config.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <string.h>
 #include <BlueSCSI_platform.h>
 
 // Use variables for version number
@@ -90,8 +91,8 @@
 */
 int getBlockSize(char *filename, int scsiId, int default_size);
 
-int getImgDir(int scsiId, char* dirname);
+int getImgDir(int scsiId, char* dirname, size_t dname_len);
 
-int getImg(int scsiId, int img_index, char* filename);
+int getImg(int scsiId, int img_index, char* filename, size_t fname_len);
 
 int getToolBoxSharedDir(char * dir_name);

--- a/src/BlueSCSI_disk.cpp
+++ b/src/BlueSCSI_disk.cpp
@@ -633,7 +633,7 @@ static void scsiDiskLoadConfig(int target_idx, const char *section)
     if (strlen(section) == 5 && strncmp(section, "SCSI", 4) == 0) // allow within target [SCSIx] blocks only
     {
         ini_gets(section, "ImgDir", "", tmp, sizeof(tmp), CONFIGFILE);
-        getImgDir(target_idx, tmp);
+        getImgDir(target_idx, tmp, sizeof(tmp));
         if (tmp[0])
         {
             log("-- SCSI", target_idx, " using image directory \'", tmp, "'");
@@ -787,7 +787,7 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buf_len)
     {
         // image directory was found during startup
         char dirname[MAX_FILE_PATH];
-        int dir_len = getImgDir(target_idx, dirname);
+        int dir_len = getImgDir(target_idx, dirname, sizeof(dirname));
         if (!dir_len)
         {
             // If image_directory set but ImgDir is not look for a well known ImgDir
@@ -844,7 +844,7 @@ int scsiDiskGetNextImageName(image_config_t &img, char *buf, size_t buf_len)
             img.image_index = 0;
         }
 
-        int ret = getImg(target_idx, img.image_index, buf);
+        int ret = getImg(target_idx, img.image_index, buf, buf_len);
         if (buf[0] != '\0')
         {
             return ret;


### PR DESCRIPTION
Since commit dd12606728f67496916aa73723a4109fa6d78991, the handling of files assigned to SCSI IDs with the IMG0...IMG9 key is broken if the file name is longer than 3 characters.

DIR0...DIR9 is broken in a similar fashion.

Using RAW sections of the SD card is broken as well if specified in the .ini file.

This PR passes  the buffer length in getImg() and getDir() so that the file and directory names do not get truncated at the size of a char pointer.