### PR TITLE
reinitSCSI: Only platform_network_wifi_join if SSID is present

### DIFF
--- a/src/BlueSCSI.cpp
+++ b/src/BlueSCSI.cpp
@@ -551,7 +551,10 @@ static void reinitSCSI()
   if (scsiDiskCheckAnyNetworkDevicesConfigured())
   {
     platform_network_init(scsiDev.boardCfg.wifiMACAddress);
-    platform_network_wifi_join(scsiDev.boardCfg.wifiSSID, scsiDev.boardCfg.wifiPassword);
+    if (scsiDev.boardCfg.wifiSSID[0] != '\0')
+    {
+      platform_network_wifi_join(scsiDev.boardCfg.wifiSSID, scsiDev.boardCfg.wifiPassword);
+    }
   }
 #endif
 }


### PR DESCRIPTION
I didn't intend for this to be the default behavior and it's just (bad) luck that if you pass null strings to `cyw43_arch_wifi_connect_async` it will connect to the first available SSID with no security.  This is insecure and in my case it's making it hard to test something since there's no current way to leave it unconfigured.

I think users should be required to at least put their SSID in the config even if their network is unencrypted, or use the Wi-Fi DA.