### PR TITLE
Added GPIO_USB_POWER to the platform GPIO definition

### DIFF
--- a/lib/BlueSCSI_platform_RP2MCU/BlueSCSI_platform_gpio_v2.h
+++ b/lib/BlueSCSI_platform_RP2MCU/BlueSCSI_platform_gpio_v2.h
@@ -93,6 +93,7 @@ extern uint32_t SCSI_ACCEL_PINMASK;
 
 // Other pins
 #define SWO_PIN 16
+#define GPIO_USB_POWER 24
 
 // Status line outputs for initiator mode
 #define SCSI_OUT_ACK  26


### PR DESCRIPTION
USB mass storage mode does not work on Pico/Pico2 without 'w' because the USB power check fails due to GPIO24 not being initialized.

initialize GPIO:
https://github.com/BlueSCSI/BlueSCSI-v2/blob/687a3537792b587066ebe41f0909c1835069a0ca/lib/BlueSCSI_platform_RP2MCU/BlueSCSI_platform.cpp#L525-L527

USB power supply check:
https://github.com/BlueSCSI/BlueSCSI-v2/blob/687a3537792b587066ebe41f0909c1835069a0ca/lib/BlueSCSI_platform_RP2MCU/BlueSCSI_platform_msc.cpp#L119-L121