### PR TITLE
[Tester needed] - Fixed VHD support in Initiator mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ set(COMMON_SOURCES
     src/BlueSCSI_blink.cpp
     src/BlueSCSI_mode.cpp
     src/BlueSCSI_initiator.cpp
+    src/BlueSCSI_vhd.cpp
     src/BlueSCSI_msc.cpp
     src/BlueSCSI_msc_initiator.cpp
     src/BlueSCSI_Toolbox.cpp
@@ -513,6 +514,7 @@ set(BOOTLOADER_SOURCES
     src/BlueSCSI_log.cpp
     src/BlueSCSI_log_trace.cpp
     src/BlueSCSI_initiator.cpp
+    src/BlueSCSI_vhd.cpp
     src/BlueSCSI_msc.cpp
     src/BlueSCSI_msc_initiator.cpp
     src/ImageBackingStore.cpp

--- a/lib/BlueSCSI_platform_RP2MCU/rp2040-template.ld
+++ b/lib/BlueSCSI_platform_RP2MCU/rp2040-template.ld
@@ -209,6 +209,7 @@ SECTIONS
 
         /* SCSI Initiator mode code. These will fit in cache when in use. */
         *BlueSCSI_initiator.cpp.o(.text .text*)
+        *BlueSCSI_vhd.cpp.o(.text .text*)
         *BlueSCSI_msc_initiator.cpp.o(.text .text*)
         *scsi_accel_host*(.text .text*)
         *scsiHostPhy*(.text .text*)

--- a/lib/BlueSCSI_platform_RP2MCU/scsiHostPhy.cpp
+++ b/lib/BlueSCSI_platform_RP2MCU/scsiHostPhy.cpp
@@ -177,14 +177,23 @@ int scsiHostPhyGetPhase()
     if (phase == 0 && absolute_time_diff_us(last_online_time, get_absolute_time()) > 100)
     {
 
+#if defined(BLUESCSI_ULTRA) || defined(BLUESCSI_ULTRA_WIDE)
+        platform_disable_initiator_signals();
+        platform_delay_us(20);
+#else
         platform_delay_us(1);
-
+#endif
         if (!SCSI_IN(BSY))
         {
+#if defined(BLUESCSI_ULTRA) || defined(BLUESCSI_ULTRA_WIDE)
+            platform_enable_initiator_signals();
+#endif
             scsiLogInitiatorPhaseChange(BUS_FREE);
             return BUS_FREE;
         }
-
+#if defined(BLUESCSI_ULTRA) || defined(BLUESCSI_ULTRA_WIDE)
+        platform_enable_initiator_signals();
+#endif
         last_online_time = get_absolute_time();
     }
     else if (phase != 0)

--- a/src/BlueSCSI_initiator.cpp
+++ b/src/BlueSCSI_initiator.cpp
@@ -1,7 +1,7 @@
 /**
  * This file is originally part of ZuluSCSI adopted for BlueSCSI
  *
- * BlueSCSI - Copyright (c) 2024 Eric Helgeson, Androda
+ * BlueSCSI - Copyright (c) 2024-2026 Eric Helgeson, Androda
  * ZuluSCSI™ - Copyright (c) 2022-2025 Rabbit Hole Computing™
  *
  * ZuluSCSI™ firmware is licensed under the GPL version 3 or any later version. 
@@ -33,6 +33,7 @@
 #include "BlueSCSI_initiator.h"
 #include "BlueSCSI_msc_initiator.h"
 #include "BlueSCSI_msc.h"
+#include "BlueSCSI_vhd.h"
 #include <BlueSCSI_platform.h>
 #include <minIni.h>
 #include "SdFat.h"
@@ -106,6 +107,9 @@ static struct {
 
     uint32_t removable_count[8];
 
+    // VHD output format (opt-in via InitiatorVHD=1)
+    bool use_vhd_format;
+
     // Negotiated bus width for targets
     int targetBusWidth[NUM_SCSIID];
     uint32_t start_sector[NUM_SCSIID];
@@ -132,6 +136,7 @@ void scsiInitiatorInit()
     }
     g_initiator_state.max_retry_count = ini_getl("SCSI", "InitiatorMaxRetry", 5, CONFIGFILE);
     g_initiator_state.use_read10 = ini_getbool("SCSI", "InitiatorUseRead10", false, CONFIGFILE);
+    g_initiator_state.use_vhd_format = ini_getbool("SCSI", "InitiatorVHD", false, CONFIGFILE);
 
     // treat initiator id as already imaged drive so it gets skipped
     g_initiator_state.drives_imaged = 1 << g_initiator_state.initiator_id;
@@ -243,6 +248,14 @@ static int scsiTypeToIniType(int scsi_type, bool removable)
             break;
     }
     return ini_type;
+}
+
+// Check if VHD output should be used for the current target
+static bool initiatorShouldWriteVhd()
+{
+    return g_initiator_state.use_vhd_format &&
+           g_initiator_state.device_type == SCSI_DEVICE_TYPE_DIRECT_ACCESS &&
+           !g_initiator_state.removable;
 }
 
 // High level logic of the initiator mode
@@ -449,6 +462,12 @@ void scsiInitiatorMainLoop()
                     strncpy(filename_base, "RM00_imaged", sizeof(filename_base));
                     filename_extension = ".img";
                 }
+
+                if (initiatorShouldWriteVhd())
+                {
+                    filename_extension = ".vhd";
+                    logmsg("VHD output enabled for SCSI ID ", g_initiator_state.target_id);
+                }
             }
 
             if (g_initiator_state.eject_when_done && g_initiator_state.removable_count[g_initiator_state.target_id] == 0)
@@ -539,8 +558,9 @@ void scsiInitiatorMainLoop()
                     return;
                 }
 
+                uint64_t vhd_overhead = initiatorShouldWriteVhd() ? VHD_FOOTER_SIZE : 0;
                 uint64_t sd_card_free_bytes = (uint64_t)SD.vol()->freeClusterCount() * SD.vol()->bytesPerCluster();
-                if (sd_card_free_bytes < total_bytes)
+                if (sd_card_free_bytes < total_bytes + vhd_overhead)
                 {
                     logmsg("SD Card only has ", (int)(sd_card_free_bytes / (1024 * 1024)),
                            " MiB - not enough free space to image SCSI ID ", g_initiator_state.target_id);
@@ -560,7 +580,8 @@ void scsiInitiatorMainLoop()
                     // Only preallocate on exFAT, on FAT32 preallocating can result in false garbage data in the
                     // file if write is interrupted.
                     logmsg("Preallocating image file");
-                    g_initiator_state.target_file.preAllocate((uint64_t)g_initiator_state.sectorcount * g_initiator_state.sectorsize);
+                    g_initiator_state.target_file.preAllocate(
+                        (uint64_t)g_initiator_state.sectorcount * g_initiator_state.sectorsize + vhd_overhead);
                 }
 
                 logmsg("Starting to copy drive data to ", filename);
@@ -599,6 +620,25 @@ void scsiInitiatorMainLoop()
             {
                 logmsg("Marking SCSI ID, ", g_initiator_state.target_id, ", as imaged, wont ask it again.");
                 g_initiator_state.drives_imaged |= (1 << g_initiator_state.target_id);
+            }
+
+            // Write VHD footer if enabled for this target
+            if (initiatorShouldWriteVhd())
+            {
+                uint64_t raw_bytes = (uint64_t)g_initiator_state.sectorcount * g_initiator_state.sectorsize;
+                uint8_t vhd_footer[VHD_FOOTER_SIZE];
+                // Use 0 for timestamp — embedded device has no RTC epoch reference
+                vhd_build_fixed_footer(vhd_footer, raw_bytes,
+                                       g_initiator_state.sectorcount, 0,
+                                       g_initiator_state.target_id);
+                if (g_initiator_state.target_file.write(vhd_footer, VHD_FOOTER_SIZE) == VHD_FOOTER_SIZE)
+                {
+                    logmsg("VHD footer written successfully");
+                }
+                else
+                {
+                    logmsg("WARNING: Failed to write VHD footer");
+                }
             }
 
             g_initiator_state.imaging = false;
@@ -1426,5 +1466,15 @@ bool scsiInitiatorReadDataToFile(int target_id, uint32_t start_sector, uint32_t 
     }
 }
 
+#ifdef UNIT_TEST
+/* Test accessors for initiator state */
+bool test_initiator_get_use_vhd_format() {
+    return g_initiator_state.use_vhd_format;
+}
+
+bool test_initiator_should_write_vhd() {
+    return initiatorShouldWriteVhd();
+}
+#endif
 
 #endif

--- a/src/BlueSCSI_vhd.cpp
+++ b/src/BlueSCSI_vhd.cpp
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2026 Eric Helgeson
+ *
+ * BlueSCSI - Fixed VHD footer generation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+**/
+
+#include "BlueSCSI_vhd.h"
+#include <string.h>
+
+/* Write a big-endian uint16 to buffer */
+static void write_be16(uint8_t *p, uint16_t val) {
+    p[0] = (uint8_t)(val >> 8);
+    p[1] = (uint8_t)(val);
+}
+
+/* Write a big-endian uint32 to buffer */
+static void write_be32(uint8_t *p, uint32_t val) {
+    p[0] = (uint8_t)(val >> 24);
+    p[1] = (uint8_t)(val >> 16);
+    p[2] = (uint8_t)(val >> 8);
+    p[3] = (uint8_t)(val);
+}
+
+/* Write a big-endian uint64 to buffer */
+static void write_be64(uint8_t *p, uint64_t val) {
+    write_be32(p, (uint32_t)(val >> 32));
+    write_be32(p + 4, (uint32_t)(val));
+}
+
+uint32_t vhd_compute_checksum(const uint8_t *footer, size_t len)
+{
+    uint32_t sum = 0;
+    for (size_t i = 0; i < len; i++) {
+        sum += footer[i];
+    }
+    return ~sum;
+}
+
+vhd_geometry_t vhd_compute_geometry(uint64_t total_bytes)
+{
+    /*
+     * Microsoft VHD Specification geometry algorithm.
+     * Input: total disk size in bytes.
+     * The algorithm works on 512-byte sector count.
+     */
+    vhd_geometry_t geo;
+    uint32_t totalSectors = (uint32_t)(total_bytes / 512);
+
+    /* Cap at maximum CHS addressable sectors */
+    if (totalSectors > 65535U * 16 * 255) {
+        totalSectors = 65535U * 16 * 255;
+    }
+
+    uint32_t cylinderTimesHeads;
+    uint32_t heads;
+    uint32_t sectorsPerTrack;
+
+    if (totalSectors >= 65535U * 16 * 63) {
+        sectorsPerTrack = 255;
+        heads = 16;
+        cylinderTimesHeads = totalSectors / sectorsPerTrack;
+    } else {
+        sectorsPerTrack = 17;
+        cylinderTimesHeads = totalSectors / sectorsPerTrack;
+
+        heads = (cylinderTimesHeads + 1023) / 1024;
+        if (heads < 4) {
+            heads = 4;
+        }
+
+        if (cylinderTimesHeads >= (heads * 1024) || heads > 16) {
+            sectorsPerTrack = 31;
+            heads = 16;
+            cylinderTimesHeads = totalSectors / sectorsPerTrack;
+        }
+
+        if (cylinderTimesHeads >= (heads * 1024)) {
+            sectorsPerTrack = 63;
+            heads = 16;
+            cylinderTimesHeads = totalSectors / sectorsPerTrack;
+        }
+    }
+
+    uint32_t cyl32 = cylinderTimesHeads / heads;
+    if (cyl32 > 65535) {
+        cyl32 = 65535;
+    }
+
+    geo.cylinders = (uint16_t)cyl32;
+    geo.heads = (uint8_t)heads;
+    geo.sectors_per_track = (uint8_t)sectorsPerTrack;
+    return geo;
+}
+
+/*
+ * Simple deterministic hash for UUID generation.
+ * Mixes timestamp, SCSI ID, and disk size into 16 bytes.
+ * Uses a basic multiplicative hash (FNV-1a inspired).
+ */
+static void vhd_generate_uuid(uint8_t *uuid, uint32_t timestamp,
+                               uint8_t scsi_id, uint64_t total_bytes)
+{
+    /* Seed with input data packed into a buffer */
+    uint8_t seed[16];
+    memset(seed, 0, sizeof(seed));
+    write_be32(&seed[0], timestamp);
+    seed[4] = scsi_id;
+    write_be64(&seed[5], total_bytes);
+    /* seed[13..15] remain zero, providing padding */
+
+    /* FNV-1a-like mixing to produce 16 bytes */
+    uint32_t h0 = 0x811C9DC5U;
+    uint32_t h1 = 0x01000193U;
+    uint32_t h2 = 0xDEADBEEFU;
+    uint32_t h3 = 0xCAFEBABEU;
+
+    for (int i = 0; i < 16; i++) {
+        h0 ^= seed[i];
+        h0 *= 0x01000193U;
+        h1 ^= seed[(i + 3) % 16];
+        h1 *= 0x01000193U;
+        h2 ^= seed[(i + 7) % 16];
+        h2 *= 0x01000193U;
+        h3 ^= seed[(i + 11) % 16];
+        h3 *= 0x01000193U;
+    }
+
+    write_be32(&uuid[0], h0);
+    write_be32(&uuid[4], h1);
+    write_be32(&uuid[8], h2);
+    write_be32(&uuid[12], h3);
+}
+
+void vhd_build_fixed_footer(uint8_t *footer, uint64_t total_bytes,
+                             uint32_t sectorcount, uint32_t timestamp,
+                             uint8_t scsi_id)
+{
+    (void)sectorcount; /* Reserved for future use / geometry fallback */
+
+    /* Zero entire footer first */
+    memset(footer, 0, VHD_FOOTER_SIZE);
+
+    /* Offset 0: Cookie "conectix" */
+    memcpy(&footer[0], "conectix", 8);
+
+    /* Offset 8: Features (0x00000002 = reserved, always set) */
+    write_be32(&footer[8], 0x00000002);
+
+    /* Offset 12: File Format Version (1.0) */
+    write_be32(&footer[12], 0x00010000);
+
+    /* Offset 16: Data Offset (fixed disk = no dynamic header) */
+    write_be64(&footer[16], 0xFFFFFFFFFFFFFFFFULL);
+
+    /* Offset 24: Time Stamp */
+    write_be32(&footer[24], timestamp);
+
+    /* Offset 28: Creator Application */
+    memcpy(&footer[28], "bsci", 4);
+
+    /* Offset 32: Creator Version (1.0) */
+    write_be32(&footer[32], 0x00010000);
+
+    /* Offset 36: Creator Host OS ("Wi2k" = Windows) */
+    memcpy(&footer[36], "Wi2k", 4);
+
+    /* Offset 40: Original Size */
+    write_be64(&footer[40], total_bytes);
+
+    /* Offset 48: Current Size */
+    write_be64(&footer[48], total_bytes);
+
+    /* Offset 56: Disk Geometry (CHS) */
+    vhd_geometry_t geo = vhd_compute_geometry(total_bytes);
+    write_be16(&footer[56], geo.cylinders);
+    footer[58] = geo.heads;
+    footer[59] = geo.sectors_per_track;
+
+    /* Offset 60: Disk Type (2 = Fixed) */
+    write_be32(&footer[60], 0x00000002);
+
+    /* Offset 64: Checksum — must be computed last */
+    /* Leave as zero for now */
+
+    /* Offset 68: Unique Id (16 bytes) */
+    vhd_generate_uuid(&footer[68], timestamp, scsi_id, total_bytes);
+
+    /* Offset 84: Saved State = 0 (already zeroed) */
+    /* Offset 85-511: Reserved = 0 (already zeroed) */
+
+    /* Now compute and store checksum */
+    uint32_t checksum = vhd_compute_checksum(footer, VHD_FOOTER_SIZE);
+    write_be32(&footer[64], checksum);
+}

--- a/src/BlueSCSI_vhd.h
+++ b/src/BlueSCSI_vhd.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 Eric Helgeson
+ *
+ * BlueSCSI - Fixed VHD footer generation
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+**/
+
+#ifndef BLUESCSI_VHD_H
+#define BLUESCSI_VHD_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#define VHD_FOOTER_SIZE 512
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* CHS geometry as returned by vhd_compute_geometry */
+typedef struct {
+    uint16_t cylinders;
+    uint8_t heads;
+    uint8_t sectors_per_track;
+} vhd_geometry_t;
+
+/**
+ * Build a complete 512-byte Fixed VHD footer.
+ *
+ * @param footer      Output buffer, must be at least VHD_FOOTER_SIZE bytes
+ * @param total_bytes Raw disk data size in bytes
+ * @param sectorcount Number of SCSI sectors (used for geometry fallback)
+ * @param timestamp   Seconds since 2000-01-01 00:00:00 UTC
+ * @param scsi_id     SCSI target ID (used in UUID generation)
+ */
+void vhd_build_fixed_footer(uint8_t *footer, uint64_t total_bytes,
+                             uint32_t sectorcount, uint32_t timestamp,
+                             uint8_t scsi_id);
+
+/**
+ * Compute CHS geometry per the Microsoft VHD specification algorithm.
+ *
+ * @param total_bytes Raw disk data size in bytes
+ * @return CHS geometry struct
+ */
+vhd_geometry_t vhd_compute_geometry(uint64_t total_bytes);
+
+/**
+ * Compute the VHD one's complement checksum over a 512-byte footer.
+ * The 4 checksum bytes at offset 64-67 must be zero during computation.
+ *
+ * @param footer Footer buffer (512 bytes)
+ * @param len    Length of footer (should be VHD_FOOTER_SIZE)
+ * @return One's complement of the sum of all bytes
+ */
+uint32_t vhd_compute_checksum(const uint8_t *footer, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BLUESCSI_VHD_H */


### PR DESCRIPTION
Enable with: 

```ini
[SCSI]
InitiatorVHD=1
```

Adds 512 byte footer to imaged file, eg:
```
SCSI ID 2 capacity 166200 sectors x 512 bytes
Drive total size is 81 MiB
SCSI Version 2
[SCSI2]
  Vendor = "QUANTUM "
  Product = "CTS80S          "
  Version = "4.07"
  Type = 0
VHD output enabled for SCSI ID 2
Starting to copy drive data to HD20_imaged.vhd
```

```
$ tail -c 512 HD20_imaged.vhd| hexdump -C
00000000  63 6f 6e 65 63 74 69 78  00 00 00 02 00 01 00 00  |conectix........|
00000010  ff ff ff ff ff ff ff ff  00 00 00 00 62 73 63 69  |............bsci|
00000020  00 01 00 00 57 69 32 6b  00 00 00 00 05 12 70 00  |....Wi2k......p.|
00000030  00 00 00 00 05 12 70 00  03 d1 0a 11 00 00 00 02  |......p.........|
00000040  ff ff e7 72 89 85 23 72  e0 63 7d 4a cc 5f f7 82  |...r..#r.c}J._..|
00000050  88 25 ca 6f 00 00 00 00  00 00 00 00 00 00 00 00  |.%.o............|
00000060  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000200
```