### PR TITLE
Fix SD card firmware update failure for non-Ultra targets

### DIFF
--- a/lib/BlueSCSI_platform_RP2MCU/BlueSCSI_platform.cpp
+++ b/lib/BlueSCSI_platform_RP2MCU/BlueSCSI_platform.cpp
@@ -748,18 +748,19 @@ bool checkIs2023a() {
 }
 
 void platform_setup_sd() {
-#if defined(BLUESCSI_ULTRA) || defined(BLUESCSI_ULTRA_WIDE) 
+#if defined(BLUESCSI_ULTRA) || defined(BLUESCSI_ULTRA_WIDE)
     i2c_init(i2c1, 100000);
-#endif
+#else
     // SD card pins
     // Card is used in SDIO mode for main program, and in SPI mode for crash handler & bootloader.
     //        pin             function       pup   pdown  out    state fast
-    // gpio_conf(SD_SPI_SCK,     GPIO_FUNC_SPI, true, false, true,  true, true);
-    // gpio_conf(SD_SPI_MOSI,    GPIO_FUNC_SPI, true, false, true,  true, true);
-    // gpio_conf(SD_SPI_MISO,    GPIO_FUNC_SPI, true, false, false, true, true);
-    // gpio_conf(SD_SPI_CS,      GPIO_FUNC_SIO, true, false, true,  true, true);
-    // gpio_conf(SDIO_D1,        GPIO_FUNC_SIO, true, false, false, true, true);
-    // gpio_conf(SDIO_D2,        GPIO_FUNC_SIO, true, false, false, true, true);
+    gpio_conf(SD_SPI_SCK,     GPIO_FUNC_SPI, true, false, true,  true, true);
+    gpio_conf(SD_SPI_MOSI,    GPIO_FUNC_SPI, true, false, true,  true, true);
+    gpio_conf(SD_SPI_MISO,    GPIO_FUNC_SPI, true, false, false, true, true);
+    gpio_conf(SD_SPI_CS,      GPIO_FUNC_SIO, true, false, true,  true, true);
+    gpio_conf(SDIO_D1,        GPIO_FUNC_SIO, true, false, false, true, true);
+    gpio_conf(SDIO_D2,        GPIO_FUNC_SIO, true, false, false, true, true);
+#endif
 }
 
 #ifdef BLUESCSI_MCU_RP23XX

--- a/lib/BlueSCSI_platform_RP2MCU/BlueSCSI_platform.h
+++ b/lib/BlueSCSI_platform_RP2MCU/BlueSCSI_platform.h
@@ -252,7 +252,7 @@ void platform_set_sd_callback(sd_callback_t func, const uint8_t *buffer);
 
 // Reprogram firmware in main program area.
 #ifndef RP2040_DISABLE_BOOTLOADER
-#define PLATFORM_BOOTLOADER_SIZE (256 * 1024)
+#define PLATFORM_BOOTLOADER_SIZE (128 * 1024)
 #define PLATFORM_FLASH_TOTAL_SIZE (1024 * 1024)
 #define PLATFORM_FLASH_PAGE_SIZE 4096
 bool platform_rewrite_flash_page(uint32_t offset, uint8_t buffer[PLATFORM_FLASH_PAGE_SIZE]);

--- a/lib/BlueSCSI_platform_RP2MCU/rp2040-template.ld
+++ b/lib/BlueSCSI_platform_RP2MCU/rp2040-template.ld
@@ -40,12 +40,12 @@ SECTIONS
     ASSERT(__boot2_end__ - __boot2_start__ == 256,
         "ERROR: Pico second stage bootloader must be 256 bytes in size")
 
-    /* If BlueSCSI SD card bootloader is included, it goes in first 128 kB */
+    /* If BlueSCSI SD card bootloader is included, it goes here */
     .text.bootloader : ALIGN(16) SUBALIGN(16)
     {
         KEEP(*(.text.btldr*))
-        . = ALIGN(262144);
-        CHECK_BOOTLOADER_SIZE = 1 / (. <= 262144);
+        . = ALIGN($bootloader_size);
+        CHECK_BOOTLOADER_SIZE = 1 / (. <= $bootloader_size);
     } > FLASH
 
     .text : {

--- a/lib/BlueSCSI_platform_RP2MCU/rp23xx-template.ld
+++ b/lib/BlueSCSI_platform_RP2MCU/rp23xx-template.ld
@@ -52,12 +52,12 @@ SECTIONS
        cold boot.
     */
 
-    /* If BlueSCSI SD card bootloader is included, it goes in first 256 kB */
+    /* If BlueSCSI SD card bootloader is included, it goes here */
     .text.bootloader : ALIGN(16) SUBALIGN(16)
     {
         KEEP(*(.text.btldr*))
-        . = ALIGN(262144);
-        CHECK_BOOTLOADER_SIZE = 1 / (. <= 262144);
+        . = ALIGN($bootloader_size);
+        CHECK_BOOTLOADER_SIZE = 1 / (. <= $bootloader_size);
     } > FLASH
 
     .text : {

--- a/lib/BlueSCSI_platform_RP2MCU/sd_card_sdio.cpp
+++ b/lib/BlueSCSI_platform_RP2MCU/sd_card_sdio.cpp
@@ -837,7 +837,7 @@ bool SdioCard::stopTransmission(bool blocking)
             if (g_record_sdio_errors) {
                 logmsg("SdioCard::stopTransmission() timeout");
 #ifdef ULTRA_SDIO
-                logmsg("M: ", (int)current_sdio_speed_mode, ", DIV: ", current_sdio_clock_divisor);
+                logmsg("M: ", (int)current_sdio_speed_mode, ", DIV: ", (int)current_sdio_clock_divisor);
                 logmsg("GPIO: ", (uint32_t)sio_hw->gpio_in, ", OE: ", (uint32_t)sio_hw->gpio_oe, ", S: ", (uint32_t)sio_hw->gpio_out);
 #endif
             }

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,6 +21,7 @@ board_build.core = earlephilhower
 board_build.ldscript = ${BUILD_DIR}/rp_linker.ld ; created by src/process-linker-script.py
 framework = arduino
 program_flash_allocation = 1273856
+bootloader_flash_allocation = 131072
 lib_deps =
     SdFat=https://github.com/BlueSCSI/SdFat#bluescsi-fastseek
     minIni

--- a/src/build_bootloader.py
+++ b/src/build_bootloader.py
@@ -74,7 +74,7 @@ bootloader_bin = env.ElfToBin(
 def print_bootloader_size(source, target, env):
     bootloader_bin_path = str(target[0].get_abspath())
     size = os.path.getsize(bootloader_bin_path)
-    max_size = 131072  # 128k
+    max_size = int(env.GetProjectOption("bootloader_flash_allocation", "131072"))
     percentage = (size / max_size) * 100
     print(f"Bootloader binary size: {size} / {max_size} bytes ({percentage:.2f}%)")
 

--- a/src/process-linker-script.py
+++ b/src/process-linker-script.py
@@ -25,7 +25,8 @@ linker_file = env.subst('$BUILD_DIR') + '/rp_linker.ld'
 def process_template(source, target, env):
     values = {
         'program_size': env.GetProjectOption('program_flash_allocation'),
-        'project_name': env.subst('$PIOENV')
+        'project_name': env.subst('$PIOENV'),
+        'bootloader_size': env.GetProjectOption('bootloader_flash_allocation', '131072')
         }
     with open(template_file, 'r') as t:
         src = Template(t.read())


### PR DESCRIPTION
The bootloader size was globally set to 256KB, shifting the firmware offset in .bin files from 0x20000 to 0x40000. Old 128KB bootloaders on Pico/Pico2 would seek to 128KB, read zero-padding, and fail with "Invalid firmware file, starts with: 0x00 0x00 0x00 0x00..."

Root cause: a single logmsg() call with a float clock divisor pulled in _svfprintf_r (8.6KB float printf), pushing the Ultra bootloader over 128KB and triggering the bump to 256KB for all targets.

Fix the float log by casting to int, restoring all bootloaders to 128KB. Also restore SPI pin config in platform_setup_sd() for non-Ultra targets, and template the bootloader size in linker scripts so it's configurable from platformio.ini.

Fixes #334