### PR TITLE
fix: SPDIF PLAY AUDIO uses wrong offset for tracks with PREGAP

### DIFF
--- a/src/BlueSCSI_cdrom.cpp
+++ b/src/BlueSCSI_cdrom.cpp
@@ -1543,7 +1543,7 @@ static void doPlayAudio(uint32_t lba, uint32_t length)
         }
 
         uint64_t offset = trackinfo.file_offset
-                + trackinfo.sector_length * (lba - trackinfo.track_start);
+                + trackinfo.sector_length * ((int64_t)lba - trackinfo.data_start);
         dbgmsg("------ Play audio CD: ", (int)length, " sectors starting at ", (int)lba,
            ", track number ", trackinfo.track_number, ", data offset in file ", (int)offset);
 
@@ -2701,5 +2701,19 @@ uint32_t cdromTestCalcTrackEndLBA(uint32_t data_start, uint64_t file_size,
     // This matches the calculation in getTrackFromLBA's cache check
     return data_start + (file_size > file_offset
         ? (file_size - file_offset) / sector_length : 0);
+}
+
+/*
+ * Test accessor for SPDIF PLAY AUDIO file offset calculation.
+ *
+ * Given a CUETrackInfo and an LBA, compute the byte offset in the BIN file
+ * where audio data should be read from. This must use data_start (not
+ * track_start) because file_offset corresponds to the INDEX 01 position.
+ */
+uint64_t cdromTestCalcAudioOffset(const CUETrackInfo *trackinfo, uint32_t lba)
+{
+    // This matches the calculation in doPlayAudio (SPDIF path)
+    return trackinfo->file_offset
+        + trackinfo->sector_length * ((int64_t)lba - trackinfo->data_start);
 }
 #endif


### PR DESCRIPTION
The doPlayAudio SPDIF path computed the BIN file byte offset using track_start, but file_offset corresponds to data_start (INDEX 01). For tracks with unstored PREGAP, track_start < data_start, causing the seek to land too far into the file by pregap_length * sector_size bytes. This played wrong audio data on discs like Tatsujin Ou on FM Towns where Track 2 has PREGAP 00:02:00.

Use data_start (matching the Read CD path) and int64_t cast to handle LBAs in the pregap region correctly.