### PR TITLE
fix: correct TurboMax clk_hz from 252MHz to 250MHz

### DIFF
--- a/lib/BlueSCSI_platform_RP2MCU/timings_RP2MCU.c
+++ b/lib/BlueSCSI_platform_RP2MCU/timings_RP2MCU.c
@@ -288,7 +288,7 @@ static bluescsi_timings_t  predefined_timings[]  = {
     },
     // predefined_timings[4] - 250000000
     {
-        .clk_hz = 252000000,
+        .clk_hz = 250000000,
 
         .pll =
         {


### PR DESCRIPTION
This was an accidental change in 75d0b6b0a