### PR TITLE
toolbox: Skip DATA_OUT phase on zero-length SET_WORKING_DIR

### DIFF
--- a/src/BlueSCSI_Toolbox.cpp
+++ b/src/BlueSCSI_Toolbox.cpp
@@ -285,6 +285,17 @@ static void onGetCapabilities()
 static void onSetWorkingDir()
 {
     uint8_t path_len = scsiDev.cdb[8];
+
+    // Parameter list length of zero: no data to transfer, no state change.
+    // Matches SCSI-2 convention used by MODE SELECT. Clients that want to
+    // reset the override must send a 1-byte NUL path explicitly.
+    if (path_len == 0)
+    {
+        dbgmsg("TOOLBOX SET_WORKING_DIR: zero-length, no change");
+        scsiDev.phase = STATUS;
+        return;
+    }
+
     if (path_len > 64) path_len = 64;
 
     char path[65] = {0};
@@ -294,7 +305,7 @@ static void onSetWorkingDir()
 
     if (path[0] == '\0')
     {
-        // Empty string: reset to default
+        // Empty C string reset to default
         g_toolbox_dir_override[0] = '\0';
         dbgmsg("TOOLBOX SET_WORKING_DIR: reset to default");
     }


### PR DESCRIPTION
CDB[8]=0 on SET_WORKING_DIR now returns STATUS with no state change, matching the SCSI-2 convention already used by MODE SELECT a parameter list length of zero means no data shall be transferred and shall not be treated as an error.

Clients that want to reset the override must continue to send a 1-byte NUL path explicitly (CDB[8]=1, data=0x00). An all-NUL multi-byte payload (e.g. CDB[8]=4 with four NUL bytes) resets as well.

Thanks saybur!