### PR TITLE
disk: fix data corruption on 256-byte sector images

### DIFF
--- a/src/BlueSCSI_disk.cpp
+++ b/src/BlueSCSI_disk.cpp
@@ -2709,10 +2709,14 @@ static void start_dataInTransfer(uint8_t *buffer, uint32_t count)
     image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
     platform_set_sd_callback(&diskDataIn_callback, buffer);
 
-    // Use direct sector I/O when fastseek is enabled (for fragmented files)
-    // Contiguous files already use raw SD access, bypassing this path
+    // Use direct sector I/O when fastseek is enabled (for fragmented files).
+    // Contiguous files already use raw SD access, bypassing this path.
+    // Direct reads go sector-by-sector at 512 bytes, so they only apply when
+    // the image uses a 512-byte SCSI block size — 256-byte images would hit
+    // unaligned positions/counts and silently corrupt the buffer.
     bool read_ok = false;
-    if (img.file.isFastSeekEnabled())
+    uint32_t bytesPerSector = scsiDev.target->liveCfg.bytesPerSector;
+    if (img.file.isFastSeekEnabled() && bytesPerSector == SD_SECTOR_SIZE)
     {
         // Convert byte position/count to sector units (>> 9 is / 512)
         uint32_t fileSector = img.file.position() >> 9;

--- a/src/BlueSCSI_disk.cpp
+++ b/src/BlueSCSI_disk.cpp
@@ -2855,10 +2855,16 @@ static void start_dataInTransfer(uint8_t *buffer, uint32_t count)
     image_config_t &img = *(image_config_t*)scsiDev.target->cfg;
     platform_set_sd_callback(&diskDataIn_callback, buffer);
 
-    // Use direct sector I/O when fastseek is enabled (for fragmented files)
-    // Contiguous files already use raw SD access, bypassing this path
+    // Use direct sector I/O when fastseek is enabled (for fragmented files).
+    // Contiguous files already use raw SD access, bypassing this path.
+    // Direct reads address the card in whole 512-byte SD sectors, so both the
+    // position and the length must be sector aligned. 512-byte and larger
+    // block sizes (CD-ROM 2048 etc.) always are; 256-byte images usually are
+    // not, and truncating them here silently corrupts the transfer.
     bool read_ok = false;
-    if (img.file.isFastSeekEnabled())
+    bool sector_aligned = ((img.file.position() % SD_SECTOR_SIZE) == 0) &&
+                          ((count % SD_SECTOR_SIZE) == 0);
+    if (img.file.isFastSeekEnabled() && sector_aligned)
     {
         // Convert byte position/count to sector units (>> 9 is / 512)
         uint32_t fileSector = img.file.position() >> 9;
@@ -2896,6 +2902,11 @@ static void start_dataInTransfer(uint8_t *buffer, uint32_t count)
     // a large transfer compared to its transfer speed.
     platform_reset_watchdog();
 }
+
+#ifdef UNIT_TEST
+/* Test accessor - exercises the SD read path selection in start_dataInTransfer() */
+void testStartDataInTransfer(uint8_t *buffer, uint32_t count) { start_dataInTransfer(buffer, count); }
+#endif
 
 static void diskDataIn()
 {

--- a/src/ImageBackingStore.cpp
+++ b/src/ImageBackingStore.cpp
@@ -303,6 +303,15 @@ ssize_t ImageBackingStore::read(void* buf, size_t count)
     uint32_t sectorcount = count / SD_SECTOR_SIZE;
     if (m_iscontiguous && (uint64_t)sectorcount * SD_SECTOR_SIZE != count)
     {
+        // While contiguous, m_fsfile's position was never advanced — sync it
+        // from the raw cursor before the SdFat path takes over, otherwise the
+        // fallback read lands at file offset 0.
+        uint64_t pos = (uint64_t)(m_cursector - m_bgnsector) * SD_SECTOR_SIZE;
+        if (!m_israw && m_fsfile.isOpen() && !m_fsfile.seek(pos))
+        {
+            logmsg("---- Failed to sync FsFile position during contiguous read fallback");
+            return -1;
+        }
         dbgmsg("---- Unaligned access to image, falling back to SdFat access mode");
         m_iscontiguous = false;
     }
@@ -345,6 +354,14 @@ ssize_t ImageBackingStore::write(const void* buf, size_t count)
     uint32_t sectorcount = count / SD_SECTOR_SIZE;
     if (m_iscontiguous && (uint64_t)sectorcount * SD_SECTOR_SIZE != count)
     {
+        // Mirror of read(): sync FsFile position from the raw cursor before
+        // handing off to SdFat, or the fallback write lands at offset 0.
+        uint64_t pos = (uint64_t)(m_cursector - m_bgnsector) * SD_SECTOR_SIZE;
+        if (!m_israw && m_fsfile.isOpen() && !m_fsfile.seek(pos))
+        {
+            logmsg("---- Failed to sync FsFile position during contiguous write fallback");
+            return -1;
+        }
         dbgmsg("---- Unaligned access to image, falling back to SdFat access mode");
         m_iscontiguous = false;
     }

--- a/src/ImageBackingStore.cpp
+++ b/src/ImageBackingStore.cpp
@@ -303,6 +303,15 @@ ssize_t ImageBackingStore::read(void* buf, size_t count)
     uint32_t sectorcount = count / SD_SECTOR_SIZE;
     if (m_iscontiguous && (uint64_t)sectorcount * SD_SECTOR_SIZE != count)
     {
+        // While contiguous, m_fsfile's position was never advanced - sync it
+        // from the raw cursor before the SdFat path takes over, otherwise the
+        // fallback read lands at file offset 0.
+        uint64_t pos = (uint64_t)(m_cursector - m_bgnsector) * SD_SECTOR_SIZE;
+        if (!m_israw && m_fsfile.isOpen() && !m_fsfile.seek(pos))
+        {
+            logmsg("---- Failed to sync FsFile position during contiguous read fallback");
+            return -1;
+        }
         dbgmsg("---- Unaligned access to image, falling back to SdFat access mode");
         m_iscontiguous = false;
     }
@@ -345,6 +354,14 @@ ssize_t ImageBackingStore::write(const void* buf, size_t count)
     uint32_t sectorcount = count / SD_SECTOR_SIZE;
     if (m_iscontiguous && (uint64_t)sectorcount * SD_SECTOR_SIZE != count)
     {
+        // Mirror of read(): sync FsFile position from the raw cursor before
+        // handing off to SdFat, or the fallback write lands at offset 0.
+        uint64_t pos = (uint64_t)(m_cursector - m_bgnsector) * SD_SECTOR_SIZE;
+        if (!m_israw && m_fsfile.isOpen() && !m_fsfile.seek(pos))
+        {
+            logmsg("---- Failed to sync FsFile position during contiguous write fallback");
+            return -1;
+        }
         dbgmsg("---- Unaligned access to image, falling back to SdFat access mode");
         m_iscontiguous = false;
     }


### PR DESCRIPTION
Two related bugs surfaced on images formatted with 256-byte SCSI sectors.

1. start_dataInTransfer() used readSectorsDirect with count >> 9 when fastseek was enabled, silently dropping the trailing 256 bytes on odd-block transfers and reading the wrong 512 bytes when the file position was not 512-aligned. Gate the direct-read path on bytesPerSector == SD_SECTOR_SIZE; 256-byte images take the regular img.file.read() path.

2. ImageBackingStore::read/write kept m_fsfile's position stale while serving contiguous raw-block I/O. On the first unaligned access the code flipped m_iscontiguous=false and fell back to m_fsfile still sitting at offset 0, corrupting both reads (wrong data) and writes (overwrote the image header). Sync m_fsfile from m_cursector before the mode transition in both read() and write().

Replaces #348 