### PR TITLE
vhd: load VHD files as emulated SCSI targets

### DIFF
--- a/src/BlueSCSI_disk.cpp
+++ b/src/BlueSCSI_disk.cpp
@@ -39,6 +39,7 @@
 #include "ImageBackingStore.h"
 #include "ROMDrive.h"
 #include "QuirksCheck.h"
+#include "BlueSCSI_vhd.h"
 #include <minIni.h>
 #include <string.h>
 #include <strings.h>
@@ -438,6 +439,48 @@ static void autoConfigGeometry(image_config_t &img)
         );
 }
 
+// Read and validate a VHD footer from an already-open ImageBackingStore.
+// Returns true and populates info on VHD_PARSE_OK; returns false on any error
+// (caller should close the file and reject the image).
+static bool tryLoadVhdFooter(ImageBackingStore &file, const char *filename,
+                             vhd_footer_info_t *info)
+{
+    uint64_t filesize = file.size();
+    if (filesize < VHD_FOOTER_SIZE)
+    {
+        logmsg("---- VHD file too small (", (int)filesize, " bytes), ignoring: ", filename);
+        return false;
+    }
+
+    uint8_t footer[VHD_FOOTER_SIZE];
+    if (!file.seek(filesize - VHD_FOOTER_SIZE) ||
+        file.read(footer, VHD_FOOTER_SIZE) != (ssize_t)VHD_FOOTER_SIZE)
+    {
+        logmsg("---- Failed to read VHD footer from ", filename);
+        return false;
+    }
+
+    int rc = vhd_parse_fixed_footer(footer, VHD_FOOTER_SIZE, info);
+    if (rc != VHD_PARSE_OK)
+    {
+        const char *reason = "unknown error";
+        switch (rc) {
+            case VHD_PARSE_ERR_COOKIE:       reason = "missing conectix cookie"; break;
+            case VHD_PARSE_ERR_VERSION:      reason = "unsupported format version"; break;
+            case VHD_PARSE_ERR_CHECKSUM:     reason = "footer checksum mismatch"; break;
+            case VHD_PARSE_ERR_TYPE_DYNAMIC: reason = "Dynamic VHD not supported (fixed only)"; break;
+            case VHD_PARSE_ERR_TYPE_DIFF:    reason = "Differencing VHD not supported (fixed only)"; break;
+            case VHD_PARSE_ERR_TYPE_UNKNOWN: reason = "unknown VHD disk type"; break;
+            case VHD_PARSE_ERR_SIZE:         reason = "invalid current size"; break;
+        }
+        logmsg("---- Invalid VHD: ", filename, " (", reason, ")");
+        return false;
+    }
+
+    file.seek(0);
+    return true;
+}
+
 bool scsiDiskOpenHDDImage(int target_idx, const char *filename, int scsi_lun, int blocksize, S2S_CFG_TYPE type, bool use_prefix)
 {
     image_config_t &img = g_DiskImages[target_idx];
@@ -497,10 +540,49 @@ bool scsiDiskOpenHDDImage(int target_idx, const char *filename, int scsi_lun, in
         img.file = ImageBackingStore(filename, blocksize);
     }
 
+    // VHD detection: parse footer before computing capacity/geometry.
+    // .vhd is restricted to disk images — on other device types we reject it.
+    bool is_vhd = hasExtension(filename, ".vhd");
+    vhd_footer_info_t vhd_info;
+    bool vhd_ok = false;
+    if (is_vhd && img.file.isOpen())
+    {
+        S2S_CFG_TYPE effective_type = (S2S_CFG_TYPE) g_scsi_settings.getDevice(target_idx)->deviceType;
+        if (effective_type == S2S_CFG_NOT_SET) effective_type = type;
+        if (effective_type != S2S_CFG_FIXED)
+        {
+            logmsg("---- Rejecting .vhd on non-HD device type ", (int)effective_type,
+                   " for ", filename, " (VHD is disk-only)");
+            img.file.close();
+            return false;
+        }
+        if (blocksize != 512)
+        {
+            logmsg("---- Rejecting .vhd ", filename, " with blocksize ",
+                   (int)blocksize, " (VHD spec mandates 512-byte sectors)");
+            img.file.close();
+            return false;
+        }
+        if (!tryLoadVhdFooter(img.file, filename, &vhd_info))
+        {
+            img.file.close();
+            return false;
+        }
+        vhd_ok = true;
+        logmsg("---- VHD creator '", vhd_info.creator_app,
+               "' os '", vhd_info.creator_os,
+               "' size ", (int)(vhd_info.current_size >> 20), " MiB CHS ",
+               (int)vhd_info.cylinders, "/",
+               (int)vhd_info.heads, "/",
+               (int)vhd_info.sectors_per_track);
+    }
+
     if (img.file.isOpen())
     {
         img.bytesPerSector = blocksize;
-        img.scsiSectors = img.file.size() / blocksize;
+        img.scsiSectors = vhd_ok
+            ? (uint32_t)(vhd_info.current_size / blocksize)
+            : (uint32_t)(img.file.size() / blocksize);
         img.scsiId = target_idx | S2S_CFG_TARGET_ENABLED;
         img.sdSectorStart = 0;
 
@@ -539,6 +621,23 @@ bool scsiDiskOpenHDDImage(int target_idx, const char *filename, int scsi_lun, in
         {
             logmsg("---- Configuring as disk drive");
             img.deviceType = S2S_CFG_FIXED;
+
+            if (vhd_ok)
+            {
+                // CHS from footer — only if INI didn't override. scsiDiskSetImageConfig
+                // already copied INI values into img.*Track / *Cylinder; if those are
+                // zero, INI left them unset and we can use the footer's geometry.
+                if (img.sectorsPerTrack == 0 && img.headsPerCylinder == 0
+                    && vhd_info.sectors_per_track > 0 && vhd_info.heads > 0)
+                {
+                    img.sectorsPerTrack  = vhd_info.sectors_per_track;
+                    img.headsPerCylinder = vhd_info.heads;
+                    dbgmsg("---- VHD CHS applied: SPT=", (int)img.sectorsPerTrack,
+                           " H=", (int)img.headsPerCylinder);
+                }
+                // UUID -> serial, unconditionally overriding INI. Serial follows the file.
+                vhd_uuid_to_serial(vhd_info.uuid, img.serial);
+            }
         }
         else if (type == S2S_CFG_OPTICAL)
         {

--- a/src/BlueSCSI_initiator.cpp
+++ b/src/BlueSCSI_initiator.cpp
@@ -252,12 +252,16 @@ extern "C" const char *initiatorTestPeripheralTypeName(uint8_t device_type, bool
 }
 #endif
 
-// Check if VHD output should be used for the current target
+// Check if VHD output should be used for the current target.
+// VHD spec mandates 512-byte logical sectors — refuse otherwise (the footer's
+// geometry algorithm divides by 512 and would produce a file that no VHD
+// consumer accepts).
 static bool initiatorShouldWriteVhd()
 {
     return g_initiator_state.use_vhd_format &&
            g_initiator_state.device_type == SCSI_DEVICE_TYPE_DIRECT_ACCESS &&
-           !g_initiator_state.removable;
+           !g_initiator_state.removable &&
+           g_initiator_state.sectorsize == 512;
 }
 
 // High level logic of the initiator mode
@@ -474,6 +478,17 @@ void scsiInitiatorMainLoop()
                 {
                     filename_extension = ".vhd";
                     logmsg("VHD output enabled for SCSI ID ", g_initiator_state.target_id);
+                }
+                else if (g_initiator_state.use_vhd_format
+                      && g_initiator_state.device_type == SCSI_DEVICE_TYPE_DIRECT_ACCESS
+                      && !g_initiator_state.removable
+                      && g_initiator_state.sectorsize != 512)
+                {
+                    // User asked for VHD but drive has non-512 sectors. VHD spec
+                    // mandates 512; fall back to raw .hda so imaging still completes.
+                    logmsg("WARNING: VHD requested but drive uses ",
+                           (int)g_initiator_state.sectorsize,
+                           "-byte sectors (VHD requires 512). Writing raw .hda instead.");
                 }
             }
 

--- a/src/BlueSCSI_vhd.cpp
+++ b/src/BlueSCSI_vhd.cpp
@@ -40,6 +40,24 @@ static void write_be64(uint8_t *p, uint64_t val) {
     write_be32(p + 4, (uint32_t)(val));
 }
 
+/* Read a big-endian uint16 from buffer */
+static uint16_t read_be16(const uint8_t *p) {
+    return ((uint16_t)p[0] << 8) | p[1];
+}
+
+/* Read a big-endian uint32 from buffer */
+static uint32_t read_be32(const uint8_t *p) {
+    return ((uint32_t)p[0] << 24)
+         | ((uint32_t)p[1] << 16)
+         | ((uint32_t)p[2] << 8)
+         |  (uint32_t)p[3];
+}
+
+/* Read a big-endian uint64 from buffer */
+static uint64_t read_be64(const uint8_t *p) {
+    return ((uint64_t)read_be32(p) << 32) | (uint64_t)read_be32(p + 4);
+}
+
 uint32_t vhd_compute_checksum(const uint8_t *footer, size_t len)
 {
     uint32_t sum = 0;
@@ -204,4 +222,52 @@ void vhd_build_fixed_footer(uint8_t *footer, uint64_t total_bytes,
     /* Now compute and store checksum */
     uint32_t checksum = vhd_compute_checksum(footer, VHD_FOOTER_SIZE);
     write_be32(&footer[64], checksum);
+}
+
+int vhd_parse_fixed_footer(const uint8_t *footer, size_t len,
+                           vhd_footer_info_t *out)
+{
+    if (len != VHD_FOOTER_SIZE) return VHD_PARSE_ERR_COOKIE;
+    if (memcmp(footer, "conectix", 8) != 0) return VHD_PARSE_ERR_COOKIE;
+    if (read_be32(&footer[12]) != 0x00010000) return VHD_PARSE_ERR_VERSION;
+
+    /* Verify checksum: zero the 4 checksum bytes on a scratch copy, recompute, compare. */
+    uint8_t scratch[VHD_FOOTER_SIZE];
+    memcpy(scratch, footer, VHD_FOOTER_SIZE);
+    uint32_t stored = read_be32(&scratch[64]);
+    memset(&scratch[64], 0, 4);
+    uint32_t calc = vhd_compute_checksum(scratch, VHD_FOOTER_SIZE);
+    if (stored != calc) return VHD_PARSE_ERR_CHECKSUM;
+
+    uint32_t disk_type = read_be32(&footer[60]);
+    if (disk_type == VHD_DISK_TYPE_DYNAMIC)       return VHD_PARSE_ERR_TYPE_DYNAMIC;
+    if (disk_type == VHD_DISK_TYPE_DIFFERENCING)  return VHD_PARSE_ERR_TYPE_DIFF;
+    if (disk_type != VHD_DISK_TYPE_FIXED)         return VHD_PARSE_ERR_TYPE_UNKNOWN;
+
+    uint64_t cur = read_be64(&footer[48]);
+    /* Sanity: > 0 and < 4 TiB (defensive against corrupted size fields) */
+    if (cur == 0 || cur > (1ULL << 42))           return VHD_PARSE_ERR_SIZE;
+
+    out->current_size      = cur;
+    out->original_size     = read_be64(&footer[40]);
+    out->timestamp         = read_be32(&footer[24]);
+    memcpy(out->creator_app, &footer[28], 4); out->creator_app[4] = 0;
+    out->creator_version   = read_be32(&footer[32]);
+    memcpy(out->creator_os,  &footer[36], 4); out->creator_os[4]  = 0;
+    out->cylinders         = read_be16(&footer[56]);
+    out->heads             = footer[58];
+    out->sectors_per_track = footer[59];
+    out->disk_type         = disk_type;
+    memcpy(out->uuid, &footer[68], 16);
+    out->saved_state       = footer[84];
+    return VHD_PARSE_OK;
+}
+
+void vhd_uuid_to_serial(const uint8_t *uuid, char *serial)
+{
+    static const char hex[] = "0123456789abcdef";
+    for (int i = 0; i < 8; i++) {
+        serial[i * 2]     = hex[(uuid[i] >> 4) & 0xF];
+        serial[i * 2 + 1] = hex[ uuid[i]       & 0xF];
+    }
 }

--- a/src/BlueSCSI_vhd.h
+++ b/src/BlueSCSI_vhd.h
@@ -36,6 +36,39 @@ typedef struct {
     uint8_t sectors_per_track;
 } vhd_geometry_t;
 
+/* VHD disk types (footer offset 60) */
+#define VHD_DISK_TYPE_FIXED        2
+#define VHD_DISK_TYPE_DYNAMIC      3
+#define VHD_DISK_TYPE_DIFFERENCING 4
+
+/* Return codes for vhd_parse_fixed_footer */
+typedef enum {
+    VHD_PARSE_OK               = 0,
+    VHD_PARSE_ERR_COOKIE       = -1, /* magic "conectix" missing or len mismatch */
+    VHD_PARSE_ERR_VERSION      = -2, /* file-format version != 0x00010000 */
+    VHD_PARSE_ERR_CHECKSUM     = -3, /* one's-complement checksum mismatch */
+    VHD_PARSE_ERR_TYPE_DYNAMIC = -4, /* disk type 3 (not supported on MCU) */
+    VHD_PARSE_ERR_TYPE_DIFF    = -5, /* disk type 4 (not supported on MCU) */
+    VHD_PARSE_ERR_TYPE_UNKNOWN = -6, /* disk type not in {2,3,4} */
+    VHD_PARSE_ERR_SIZE         = -7  /* current_size zero or implausibly large */
+} vhd_parse_result_t;
+
+/* Parsed fields from a fixed VHD footer */
+typedef struct {
+    uint64_t current_size;        /* offset 48: data bytes, not including footer */
+    uint64_t original_size;       /* offset 40 */
+    uint16_t cylinders;           /* offset 56 */
+    uint8_t  heads;               /* offset 58 */
+    uint8_t  sectors_per_track;   /* offset 59 */
+    uint32_t disk_type;           /* offset 60 */
+    uint32_t timestamp;           /* offset 24 */
+    uint32_t creator_version;     /* offset 32 */
+    char     creator_app[5];      /* offset 28, 4 chars + NUL */
+    char     creator_os[5];       /* offset 36, 4 chars + NUL */
+    uint8_t  uuid[16];            /* offset 68 */
+    uint8_t  saved_state;         /* offset 84 */
+} vhd_footer_info_t;
+
 /**
  * Build a complete 512-byte Fixed VHD footer.
  *
@@ -66,6 +99,30 @@ vhd_geometry_t vhd_compute_geometry(uint64_t total_bytes);
  * @return One's complement of the sum of all bytes
  */
 uint32_t vhd_compute_checksum(const uint8_t *footer, size_t len);
+
+/**
+ * Validate and parse a 512-byte fixed VHD footer.
+ *
+ * Rejects Dynamic and Differencing VHDs (disk type 3/4) since they require
+ * an in-RAM Block Allocation Table that does not fit on the MCU.
+ *
+ * @param footer Buffer of exactly VHD_FOOTER_SIZE bytes.
+ * @param len    Length of buffer (must equal VHD_FOOTER_SIZE).
+ * @param out    Populated on VHD_PARSE_OK; untouched otherwise.
+ * @return VHD_PARSE_OK (0) on success, negative vhd_parse_result_t on failure.
+ */
+int vhd_parse_fixed_footer(const uint8_t *footer, size_t len,
+                           vhd_footer_info_t *out);
+
+/**
+ * Format a VHD UUID into a 16-character SCSI serial-number buffer.
+ * Writes lowercase hex of UUID bytes 0..7. The serial field is a fixed
+ * 16-byte field — the buffer is NOT NUL-terminated on return.
+ *
+ * @param uuid   16-byte UUID.
+ * @param serial 16-byte buffer (NOT NUL-terminated on return).
+ */
+void vhd_uuid_to_serial(const uint8_t *uuid, char *serial);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Drop a fixed vhd in the root of the sd card as `HD0 my sweet system.vhd` and it will use the metadata in BlueSCSI.