### PR TITLE
Fix issue loading RM2 + Sync on a Pico1W

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,9 +17,9 @@
           pico-sdk = pkgs.fetchFromGitHub {
             owner = "bluescsi";
             repo = "pico-sdk-internal";
-            rev = "v2.2.0-UltraSupport-rel2";
+            rev = "v2.2.0-UltraSupport-rel3";
             fetchSubmodules = true;
-            hash = "sha256-Rx+MyFQSHJuIAjClaNXGXt+vhcl0aPP5XGZkzMxLkro=";
+            hash = "sha256-C4ZCVNMlRJkDwh9h90YVmnwqFCT4ldcdHnIMskRFXhM=";
           };
 
           pico-extras = pkgs.fetchFromGitHub {

--- a/lib/BlueSCSI_platform_RP2MCU/BlueSCSI_platform.cpp
+++ b/lib/BlueSCSI_platform_RP2MCU/BlueSCSI_platform.cpp
@@ -1,5 +1,6 @@
 /**
  * ZuluSCSI™ - Copyright (c) 2022-2025 Rabbit Hole Computing™
+ * Copyright (c) 2025-2026 Eric Helgeson <eric@bluescsi.com>
  *
  * ZuluSCSI™ firmware is licensed under the GPL version 3 or any later version.
  *
@@ -841,6 +842,10 @@ void platform_init()
     // Only needed on RP2040 — see comment at __usb_timer_task definition.
     __usb_task_irq = user_irq_claim_unused(true);
     irq_set_exclusive_handler(__usb_task_irq, __usb_irq);
+    // Run tud_task() at the lowest IRQ priority so the SCSI-critical IRQs
+    // (DMA_IRQ_0 buffer-swap, selection-detect GPIO) — which sit at the
+    // default priority - always preempt an in-progress tud_task(). tud_task()
+    irq_set_priority(__usb_task_irq, PICO_LOWEST_IRQ_PRIORITY);
     irq_set_enabled(__usb_task_irq, true);
     add_alarm_in_us(1000, __usb_timer_task, NULL, true);
 #endif

--- a/lib/BlueSCSI_platform_RP2MCU/scsi_accel_target.cpp
+++ b/lib/BlueSCSI_platform_RP2MCU/scsi_accel_target.cpp
@@ -1,5 +1,6 @@
 /**
  * ZuluSCSI™ - Copyright (c) 2022-2025 Rabbit Hole Computing™
+ * Copyright (c) 2026 Eric Helgeson <eric@bluescsi.com>
  *
  * This work incorporates work from the following
  *  Copyright (c) 2023 joshua stein <jcs@jcs.org>
@@ -1095,6 +1096,33 @@ void scsi_accel_rp2040_init()
     sm_config_set_sideset_pins(&g_scsi_dma.pio_cfg_sync_write, SCSI_OUT_REQ);
     sm_config_set_out_shift(&g_scsi_dma.pio_cfg_sync_write, true, true, 32);
     sm_config_set_in_shift(&g_scsi_dma.pio_cfg_sync_write, true, true, 1);
+
+    // PIO instruction memory is shared with other subsystems (e.g. CYW43 WiFi
+    // SPI on Pico W). pio_add_program() returns a negative error when the 32
+    // instruction slots run out; unchecked, pio_sm_init() at that bogus offset
+    // makes the SM execute another program's instructions (2026.04 sync-write
+    // regression: zero-ACK hang on synchronous DATA_IN). Fail loudly.
+    {
+        static const struct { const char *name; const uint32_t *offset; } accel_progs[] = {
+            {"parity",           &g_scsi_dma.pio_offset_parity},
+            {"async_write",      &g_scsi_dma.pio_offset_async_write},
+            {"sync_write_pacer", &g_scsi_dma.pio_offset_sync_write_pacer},
+            {"read",             &g_scsi_dma.pio_offset_read},
+            {"sync_read_pacer",  &g_scsi_dma.pio_offset_sync_read_pacer},
+            {"read_parity",      &g_scsi_dma.pio_offset_read_parity},
+            {"sync_write",       &g_scsi_dma.pio_offset_sync_write},
+        };
+        for (size_t i = 0; i < sizeof(accel_progs) / sizeof(accel_progs[0]); i++)
+        {
+            if ((int32_t)*accel_progs[i].offset < 0)
+                logmsg("ERROR: SCSI accel PIO program '", accel_progs[i].name,
+                       "' failed to load, no PIO instruction memory left (",
+                       (int)*accel_progs[i].offset, ")");
+            else
+                dbgmsg("---- SCSI accel PIO program '", accel_progs[i].name,
+                       "' at offset ", (int)*accel_progs[i].offset);
+        }
+    }
 
 
     // Create DMA channel configurations so they can be applied quickly later

--- a/lib/BlueSCSI_platform_RP2MCU/sdio.cpp
+++ b/lib/BlueSCSI_platform_RP2MCU/sdio.cpp
@@ -1,6 +1,7 @@
 /** 
  * ZuluSCSI™ - Copyright (c) 2022-2025 Rabbit Hole Computing™
  * Copyright (c) 2024 Tech by Androda, LLC
+ * Copyright (c) 2026 Eric Helgeson <eric@bluescsi.com>
  *  
  * ZuluSCSI™ firmware is licensed under the GPL version 3 or any later version. 
  * 
@@ -1070,6 +1071,29 @@ sdio_status_t rp2040_sdio_stop()
 #define SDIO_PULLS_DOWN false
 #endif
 
+// Track the PIO programs this driver has loaded so that re-init can remove
+// exactly what it added. SDIO_PIO instruction memory is shared with other
+// subsystems (CYW43 WiFi SPI on Pico W, SPDIF audio on Ultra) 
+static struct {
+    const pio_program_t *cmd_rsp;
+    const pio_program_t *data_rx;
+    const pio_program_t *data_tx;
+    uint32_t cmd_rsp_offset;
+    uint32_t data_rx_offset;
+    uint32_t data_tx_offset;
+} g_sdio_loaded_programs;
+
+static void sdio_remove_loaded_programs()
+{
+    if (g_sdio_loaded_programs.cmd_rsp)
+        pio_remove_program(SDIO_PIO, g_sdio_loaded_programs.cmd_rsp, g_sdio_loaded_programs.cmd_rsp_offset);
+    if (g_sdio_loaded_programs.data_rx)
+        pio_remove_program(SDIO_PIO, g_sdio_loaded_programs.data_rx, g_sdio_loaded_programs.data_rx_offset);
+    if (g_sdio_loaded_programs.data_tx)
+        pio_remove_program(SDIO_PIO, g_sdio_loaded_programs.data_tx, g_sdio_loaded_programs.data_tx_offset);
+    memset(&g_sdio_loaded_programs, 0, sizeof(g_sdio_loaded_programs));
+}
+
 void rp2040_sdio_init(float clock_divider, uint8_t speed_mode)
 {
     #ifdef SDIO_GPIO_BASE_HIGH
@@ -1094,8 +1118,8 @@ void rp2040_sdio_init(float clock_divider, uint8_t speed_mode)
     pio_sm_set_enabled(SDIO_PIO, SDIO_CMD_SM, false);
     pio_sm_set_enabled(SDIO_PIO, SDIO_DATA_SM, false);
 
-    // Load PIO programs
-    pio_clear_instruction_memory(SDIO_PIO);
+    // Unload only the programs we loaded on a previous init 
+    sdio_remove_loaded_programs();
     
     // Set pull resistors for all SD data lines
 #if defined(BLUESCSI_ULTRA) || defined(BLUESCSI_ULTRA_WIDE)
@@ -1120,6 +1144,8 @@ void rp2040_sdio_init(float clock_divider, uint8_t speed_mode)
 
     // Command state machine
     g_sdio.pio_cmd_rsp_clk_offset = pio_add_program(SDIO_PIO, &cmd_rsp_program);
+    g_sdio_loaded_programs.cmd_rsp = &cmd_rsp_program;
+    g_sdio_loaded_programs.cmd_rsp_offset = g_sdio.pio_cmd_rsp_clk_offset;
     g_sdio.pio_cfg_cmd_rsp = pio_cmd_rsp_program_config(g_sdio.pio_cmd_rsp_clk_offset, SDIO_CMD, SDIO_CLK, clock_divider, 0);
 
     pio_sm_init(SDIO_PIO, SDIO_CMD_SM, g_sdio.pio_cmd_rsp_clk_offset, &g_sdio.pio_cfg_cmd_rsp);
@@ -1145,20 +1171,27 @@ void rp2040_sdio_init(float clock_divider, uint8_t speed_mode)
     if (speed_mode == 0) {
         g_sdio.pio_data_rx_offset = pio_add_program(SDIO_PIO, &rd_data_w_clock_default_program);
         g_sdio.pio_cfg_data_rx = pio_rd_data_w_clock_default_program_config(g_sdio.pio_data_rx_offset, SDIO_D0, SDIO_CLK, clock_divider);
+        g_sdio_loaded_programs.data_rx = &rd_data_w_clock_default_program;
     } else if (speed_mode == 1) {
         g_sdio.pio_data_rx_offset = pio_add_program(SDIO_PIO, &rd_data_w_clock_high_speed_program);
         g_sdio.pio_cfg_data_rx = pio_rd_data_w_clock_high_speed_program_config(g_sdio.pio_data_rx_offset, SDIO_D0, SDIO_CLK, clock_divider);
+        g_sdio_loaded_programs.data_rx = &rd_data_w_clock_high_speed_program;
     } else if (speed_mode == 2) {
         g_sdio.pio_data_rx_offset = pio_add_program(SDIO_PIO, &rd_data_w_clock_ultra_high_speed_program);
         g_sdio.pio_cfg_data_rx = pio_rd_data_w_clock_ultra_high_speed_program_config(g_sdio.pio_data_rx_offset, SDIO_D0, SDIO_CLK, clock_divider);
+        g_sdio_loaded_programs.data_rx = &rd_data_w_clock_ultra_high_speed_program;
     }
 #else
     g_sdio.pio_data_rx_offset = pio_add_program(SDIO_PIO, &rd_data_w_clock_program);
     g_sdio.pio_cfg_data_rx = pio_rd_data_w_clock_program_config(g_sdio.pio_data_rx_offset, SDIO_D0, SDIO_CLK, clock_divider);
+    g_sdio_loaded_programs.data_rx = &rd_data_w_clock_program;
 #endif
+    g_sdio_loaded_programs.data_rx_offset = g_sdio.pio_data_rx_offset;
 
     // Data transmission program
     g_sdio.pio_data_tx_offset = pio_add_program(SDIO_PIO, &sdio_tx_w_clock_program);
+    g_sdio_loaded_programs.data_tx = &sdio_tx_w_clock_program;
+    g_sdio_loaded_programs.data_tx_offset = g_sdio.pio_data_tx_offset;
     g_sdio.pio_cfg_data_tx = pio_sdio_tx_w_clock_program_config(g_sdio.pio_data_tx_offset, SDIO_D0, SDIO_CLK, clock_divider);
 
     // Disable SDIO pins input synchronizer.


### PR DESCRIPTION
Rework PIO loading a bit to support dynamic loading and tracking - also turn down `tud_task` to avoid any conflicts with hot path.

Thanks to @stinkerton18 for reporting/debugging with me.