### PR TITLE
network: rewrite the DaynaPORT SL003 emulation from the device ROM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,14 @@ set(INCLUDE_DIRS
 option(BLUESCSI_NETWORK_DEBUG
        "Network debug logging and DaynaPORT batch-depth instrumentation" OFF)
 
+# Which cyw43_arch variant this build uses. The poll arch has to be selected
+# by a define here; the threadsafe-background arch brings its own define with
+# the library and must NOT also see the poll one -- with both defined the SDK
+# compiles both arch implementations and they collide at link.
+if(NOT BLUESCSI_TARGET STREQUAL "Pico_2_DaynaPORT")
+    set(CYW43_ARCH_POLL_DEFINE PICO_CYW43_ARCH_POLL=1)
+endif()
+
 # Common compile definitions (from platformio.ini)
 set(COMMON_DEFINES
     PICO_FLASH_SPI_CLKDIV=2
@@ -222,7 +230,7 @@ set(COMMON_DEFINES
     RECLOCKING_SUPPORTED
     PLATFORM_HAS_INITIATOR_MODE
     DISABLE_SWO
-    PICO_CYW43_ARCH_POLL=1
+    ${CYW43_ARCH_POLL_DEFINE}
     CYW43_PIN_WL_DYNAMIC=1
     CYW43_LWIP=0
     CYW43_USE_OTP_MAC=0
@@ -386,7 +394,12 @@ elseif(BLUESCSI_TARGET STREQUAL "Pico_2_DaynaPORT")
         # a deeper ring absorbs wifi bursts between host READ(6) polls.
         NETWORK_PACKET_QUEUE_SIZE=48
     )
-    target_link_libraries(BlueSCSI PRIVATE pico_cyw43_arch_poll pico_async_context_poll)
+    # Threadsafe background rather than poll: the radio runs from a
+    # low-priority IRQ, so frames reach the receive ring during a SCSI
+    # transaction. Under the poll arch nothing services the radio while a
+    # transaction runs (scsiWrite blocks), capping a blind batch at
+    # whatever was queued when it started. Other targets remain on poll.
+    target_link_libraries(BlueSCSI PRIVATE pico_cyw43_arch_threadsafe_background pico_async_context_threadsafe_background)
     if(BLUESCSI_NETWORK_DEBUG)
         target_compile_definitions(BlueSCSI PRIVATE NETWORK_DEBUG_LOGGING)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,7 +366,11 @@ elseif(BLUESCSI_TARGET STREQUAL "Pico_Audio_SPDIF")
         CYW43_PIO_CLOCK_DIV_DYNAMIC=1
         ENABLE_AUDIO_OUTPUT
         ENABLE_AUDIO_OUTPUT_SPDIF
-        NETWORK_PACKET_QUEUE_SIZE=12
+        # Two slots fewer than the other RP2040 network targets: this
+        # linker script keeps network code in RAM (XIP-cache avoidance)
+        # and the SL003 core is larger than the handler it replaced, so
+        # the ring gives back the difference. ~1.5 KB per slot.
+        NETWORK_PACKET_QUEUE_SIZE=10
     )
     target_link_libraries(BlueSCSI PRIVATE pico_cyw43_arch_poll pico_async_context_poll)
     set_target_properties(BlueSCSI PROPERTIES OUTPUT_NAME "BlueSCSI_Pico_Audio_SPDIF")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,8 @@ set(SCSI2SD_SOURCES
     lib/SCSI2SD/src/firmware/mode.c
     lib/SCSI2SD/src/firmware/diagnostic.c
     lib/SCSI2SD/src/firmware/network.c
+    lib/SCSI2SD/src/firmware/DaynaPort/DaynaPort.c
+    lib/SCSI2SD/src/firmware/DaynaPort/sl003_core.c
     lib/SCSI2SD/src/firmware/vendor.c
     lib/SCSI2SD/src/firmware/geometry.c
     lib/SCSI2SD/src/firmware/mo.c
@@ -197,6 +199,12 @@ set(INCLUDE_DIRS
     lib/ZipParser
     lib/BlueI2S
 )
+
+# Diagnostics, off by default: network debug logging plus the DaynaPORT
+# batch-depth histogram. Configure with -DBLUESCSI_NETWORK_DEBUG=ON to get
+# them; they write to log.txt and cost time on the SCSI path.
+option(BLUESCSI_NETWORK_DEBUG
+       "Network debug logging and DaynaPORT batch-depth instrumentation" OFF)
 
 # Common compile definitions (from platformio.ini)
 set(COMMON_DEFINES
@@ -374,8 +382,14 @@ elseif(BLUESCSI_TARGET STREQUAL "Pico_2_DaynaPORT")
         BLUESCSI_DAYNAPORT
         PICO_CYW43_SUPPORTED=1
         CYW43_PIO_CLOCK_DIV_DYNAMIC=1
+        # RP2350 has RAM headroom for a deeper inbound ring (~1.5 KB/slot);
+        # a deeper ring absorbs wifi bursts between host READ(6) polls.
+        NETWORK_PACKET_QUEUE_SIZE=48
     )
     target_link_libraries(BlueSCSI PRIVATE pico_cyw43_arch_poll pico_async_context_poll)
+    if(BLUESCSI_NETWORK_DEBUG)
+        target_compile_definitions(BlueSCSI PRIVATE NETWORK_DEBUG_LOGGING)
+    endif()
     set_target_properties(BlueSCSI PROPERTIES OUTPUT_NAME "BlueSCSI_Pico_2_DaynaPORT")
 
 elseif(BLUESCSI_TARGET STREQUAL "Pico_2_Audio_SPDIF")

--- a/lib/BlueSCSI_platform_RP2MCU/BlueSCSI_platform.cpp
+++ b/lib/BlueSCSI_platform_RP2MCU/BlueSCSI_platform.cpp
@@ -1738,7 +1738,11 @@ void platform_poll()
 
 #if PICO_CYW43_SUPPORTED && !defined(BLUESCSI_BOOTLOADER_MAIN)
     if (platform_is_pico_w()) {
+#if !PICO_CYW43_ARCH_THREADSAFE_BACKGROUND
+        /* Under the threadsafe-background arch the radio drives itself from
+         * an IRQ and there is no poll entry point to call. */
         cyw43_arch_poll();
+#endif
     }
 #endif
 

--- a/lib/BlueSCSI_platform_RP2MCU/BlueSCSI_platform_network.cpp
+++ b/lib/BlueSCSI_platform_RP2MCU/BlueSCSI_platform_network.cpp
@@ -40,14 +40,22 @@ extern "C" {
 // A default DaynaPort-compatible MAC
 static const char defaultMAC[] = { 0x00, 0x80, 0x19, 0xc0, 0xff, 0xee };
 
+/*
+ * cyw43 locking under the threadsafe-background arch (the driver also
+ * runs from a low-priority IRQ). Most cyw43_* entry points take the
+ * async-context lock themselves (CYW43_THREAD_ENTER in cyw43_ctrl.c).
+ * Three do not and read IRQ-written state, so thread-context calls to
+ * them are bracketed here: cyw43_wifi_link_status, cyw43_wifi_scan_active,
+ * cyw43_wifi_get_mac. The brackets compile away under the poll arch.
+ */
+static bool network_in_use = false;
+
 // Applied from poll context on every link-up (a fresh association resets the
 // radio's power-save mode, and the cyw43 ioctl is not safe to call from
 // inside cyw43's own link-up callback).
 static volatile bool wifi_pm_setup_pending = false;
 
 extern "C" int ini_getbool(const char *section, const char *key, int defval, const char *filename);
-
-static bool network_in_use = false;
 
 // WiFi reconnection state (file-static so wifi_join can reset on credential change)
 static uint32_t wifi_reconnect_time = 0;
@@ -116,7 +124,9 @@ int platform_network_init(char *mac)
 	memcpy(cyw43_state.mac, mac, sizeof(cyw43_state.mac));
 	cyw43_arch_enable_sta_mode();
 
+	cyw43_arch_lwip_begin();
 	cyw43_wifi_get_mac(&cyw43_state, CYW43_ITF_STA, read_mac);
+	cyw43_arch_lwip_end();
 	char mac_hex_string[4*6] = {0};
 	sprintf(mac_hex_string, "%02X:%02X:%02X:%02X:%02X:%02X", read_mac[0], read_mac[1], read_mac[2], read_mac[3], read_mac[4], read_mac[5]);
 	logmsg("Wi-Fi MAC: ", mac_hex_string);
@@ -132,7 +142,9 @@ void platform_network_add_multicast_address(uint8_t *mac)
 {
 	int ret;
 
-	if ((ret = cyw43_wifi_update_multicast_filter(&cyw43_state, mac, true)) != 0)
+	/* takes the async-context lock itself */
+	ret = cyw43_wifi_update_multicast_filter(&cyw43_state, mac, true);
+	if (ret != 0)
 		logmsg( __func__, ": cyw43_wifi_update_multicast_filter: ", ret);
 }
 
@@ -188,6 +200,7 @@ void platform_network_poll()
 	static int last_network_status = CYW43_LINK_DOWN;
 	if (!network_in_use)
 		return;
+
 	if (wifi_pm_setup_pending)
 	{
 		/* Read the ini once; retry the ioctl a bounded number of
@@ -200,7 +213,9 @@ void platform_network_poll()
 		// radio's power-save so unsolicited inbound frames (ping, incoming
 		// connections) are not delayed up to a beacon interval while it
 		// dozes. Set to 1 to keep the default power-save mode for lower
-		// power draw.
+		// power draw and slightly higher bulk throughput. When enabled the
+		// chip already defaults to power-save after association, so there is
+		// nothing to apply.
 		if (pm_wanted)
 		{
 			wifi_pm_setup_pending = false;
@@ -209,12 +224,16 @@ void platform_network_poll()
 		{
 			int pmret;
 
+			/* takes the async-context lock itself */
 			pmret = cyw43_wifi_pm(&cyw43_state, CYW43_NONE_PM);
 			if (pmret == 0 || ++pm_attempts >= 10)
 				wifi_pm_setup_pending = false;
 		}
 	}
+
+	cyw43_arch_lwip_begin();
 	int status = cyw43_wifi_link_status(&cyw43_state, CYW43_ITF_STA);
+	cyw43_arch_lwip_end();
 	char * ssid = scsiDev.boardCfg.wifiSSID;
 	if ((last_network_status != status) && (status == CYW43_LINK_BADAUTH || status == CYW43_LINK_NONET || status == CYW43_LINK_FAIL || status == CYW43_LINK_NOIP))
 	{
@@ -261,7 +280,9 @@ void platform_network_poll()
 	}
 
 	last_network_status = status;
+#if !PICO_CYW43_ARCH_THREADSAFE_BACKGROUND
 	cyw43_arch_poll();
+#endif
 }
 
 int platform_network_send(uint8_t *buf, size_t len)
@@ -275,6 +296,7 @@ int platform_network_send(uint8_t *buf, size_t len)
 	uint32_t t0 = to_us_since_boot(get_absolute_time());
 #endif
 
+	/* cyw43_send_ethernet takes the async-context lock itself. */
 	ret = cyw43_send_ethernet(&cyw43_state, 0, len, buf, 0);
 	if (ret != 0)
 		logmsg("cyw43_send_ethernet failed: ", ret);
@@ -369,7 +391,12 @@ static int platform_network_wifi_scan_result(void *env, const cyw43_ev_scan_resu
 
 int platform_network_wifi_start_scan()
 {
-	if (cyw43_wifi_scan_active(&cyw43_state))
+	bool scanning;
+
+	cyw43_arch_lwip_begin();
+	scanning = cyw43_wifi_scan_active(&cyw43_state);
+	cyw43_arch_lwip_end();
+	if (scanning)
 		return -1;
 
 	cyw43_wifi_scan_options_t scan_options = { 0 };
@@ -379,7 +406,12 @@ int platform_network_wifi_start_scan()
 
 int platform_network_wifi_scan_finished()
 {
-	return !cyw43_wifi_scan_active(&cyw43_state);
+	bool scanning;
+
+	cyw43_arch_lwip_begin();
+	scanning = cyw43_wifi_scan_active(&cyw43_state);
+	cyw43_arch_lwip_end();
+	return !scanning;
 }
 
 void platform_network_wifi_dump_scan_list()
@@ -455,7 +487,14 @@ int platform_network_wifi_channel()
 // Required by cyw43_arch_wifi_connect_timeout_ms.
 int cyw43_tcpip_link_status(cyw43_t *self, int itf)
 {
-	return cyw43_wifi_link_status(self, itf);
+	int status;
+
+	/* cyw43_wifi_link_status does not lock; the async-context lock is
+	 * recursive, so bracketing is safe whether or not our caller holds it. */
+	cyw43_arch_lwip_begin();
+	status = cyw43_wifi_link_status(self, itf);
+	cyw43_arch_lwip_end();
+	return status;
 }
 
 // these override weakly-defined functions in pico-sdk

--- a/lib/BlueSCSI_platform_RP2MCU/BlueSCSI_platform_network.cpp
+++ b/lib/BlueSCSI_platform_RP2MCU/BlueSCSI_platform_network.cpp
@@ -40,6 +40,13 @@ extern "C" {
 // A default DaynaPort-compatible MAC
 static const char defaultMAC[] = { 0x00, 0x80, 0x19, 0xc0, 0xff, 0xee };
 
+// Applied from poll context on every link-up (a fresh association resets the
+// radio's power-save mode, and the cyw43 ioctl is not safe to call from
+// inside cyw43's own link-up callback).
+static volatile bool wifi_pm_setup_pending = false;
+
+extern "C" int ini_getbool(const char *section, const char *key, int defval, const char *filename);
+
 static bool network_in_use = false;
 
 // WiFi reconnection state (file-static so wifi_join can reset on credential change)
@@ -181,6 +188,32 @@ void platform_network_poll()
 	static int last_network_status = CYW43_LINK_DOWN;
 	if (!network_in_use)
 		return;
+	if (wifi_pm_setup_pending)
+	{
+		/* Read the ini once; retry the ioctl a bounded number of
+		 * times. */
+		static int pm_wanted = -1;
+		static int pm_attempts = 0;
+		if (pm_wanted < 0)
+			pm_wanted = ini_getbool("SCSI", "WiFiPowerSave", 0, CONFIGFILE);
+		// WiFiPowerSave (bluescsi.ini, [SCSI]): default 0/off disables the
+		// radio's power-save so unsolicited inbound frames (ping, incoming
+		// connections) are not delayed up to a beacon interval while it
+		// dozes. Set to 1 to keep the default power-save mode for lower
+		// power draw.
+		if (pm_wanted)
+		{
+			wifi_pm_setup_pending = false;
+		}
+		else
+		{
+			int pmret;
+
+			pmret = cyw43_wifi_pm(&cyw43_state, CYW43_NONE_PM);
+			if (pmret == 0 || ++pm_attempts >= 10)
+				wifi_pm_setup_pending = false;
+		}
+	}
 	int status = cyw43_wifi_link_status(&cyw43_state, CYW43_ITF_STA);
 	char * ssid = scsiDev.boardCfg.wifiSSID;
 	if ((last_network_status != status) && (status == CYW43_LINK_BADAUTH || status == CYW43_LINK_NONET || status == CYW43_LINK_FAIL || status == CYW43_LINK_NOIP))
@@ -439,6 +472,10 @@ void cyw43_cb_tcpip_set_link_down(cyw43_t *self, int itf)
 
 void cyw43_cb_tcpip_set_link_up(cyw43_t *self, int itf)
 {
+	// Association resets the power-save mode; (re)apply the WiFiPowerSave
+	// setting from poll context.
+	wifi_pm_setup_pending = true;
+
 	char *ssid = platform_network_wifi_ssid();
 
 	if (ssid)

--- a/lib/BlueSCSI_platform_RP2MCU/BlueSCSI_platform_network.cpp
+++ b/lib/BlueSCSI_platform_RP2MCU/BlueSCSI_platform_network.cpp
@@ -233,10 +233,32 @@ void platform_network_poll()
 
 int platform_network_send(uint8_t *buf, size_t len)
 {
-	int ret = cyw43_send_ethernet(&cyw43_state, 0, len, buf, 0);
+	int ret;
+#ifdef NETWORK_DEBUG_LOGGING
+	/* Diagnostics: time the radio send. cyw43_send_ethernet can block on
+	 * the async-context lock against the receive IRQ; the report makes
+	 * that visible from log.txt for any host. */
+	static uint32_t snd_n, snd_us_total, snd_us_max;
+	uint32_t t0 = to_us_since_boot(get_absolute_time());
+#endif
+
+	ret = cyw43_send_ethernet(&cyw43_state, 0, len, buf, 0);
 	if (ret != 0)
 		logmsg("cyw43_send_ethernet failed: ", ret);
 
+#ifdef NETWORK_DEBUG_LOGGING
+	{
+		uint32_t d = to_us_since_boot(get_absolute_time()) - t0;
+		snd_us_total += d;
+		if (d > snd_us_max) snd_us_max = d;
+		if (++snd_n % 64 == 0) {
+			LOGMSG_F("SL003 radio send over %lu frames: mean %lu us, max %lu us",
+			         (unsigned long)snd_n,
+			         (unsigned long)(snd_us_total / snd_n),
+			         (unsigned long)snd_us_max);
+		}
+	}
+#endif
 	return ret;
 }
 

--- a/lib/SCSI2SD/src/firmware/DaynaPort/DaynaPort.c
+++ b/lib/SCSI2SD/src/firmware/DaynaPort/DaynaPort.c
@@ -50,11 +50,13 @@ static bool    g_ready;
 static void ensure_init(void)
 {
 	if (!g_ready) {
-		/* scsiDev.data is the DATA OUT landing area, as it was for the
+		/* scsiDev.data is the data-phase scratch, as it was for the
 		 * pre-rewrite handler; it is far larger than SL003_PKT_MAX and
-		 * idle whenever the core fetches. */
+		 * idle whenever the core fetches. Its full size is offered so a
+		 * seamless batch goes out as one transfer at any allocation. */
 		sl003_init(&g_sl003, (const uint8_t *)scsiDev.boardCfg.wifiMACAddress,
-		           &scsiNetworkInboundQueue, scsiDev.data);
+		           &scsiNetworkInboundQueue,
+		           scsiDev.data, sizeof scsiDev.data);
 		/* DaynaPortGapHeaderUs / DaynaPortGapRecordUs ([SCSI] in
 		 * bluescsi.ini): inter-record pacing. Defaults match the real
 		 * device; software-timed blind hosts (SE/30, Plus) need them,
@@ -103,7 +105,7 @@ uint8_t scsiNetworkInquiryStatus(void)
 	ensure_init();
 	return (uint8_t)((sl003_enabled(&g_sl003) ? SL003_INQ_ENABLED : 0) |
 	                 (sl003_mode_set(&g_sl003) ? SL003_INQ_MODE_SET : 0) |
-	                 SL003_INQ_BATCH_BOUNDED);
+	                 SL003_INQ_BATCH_BOUNDED | SL003_INQ_SEAMLESS);
 }
 
 /*

--- a/lib/SCSI2SD/src/firmware/DaynaPort/DaynaPort.c
+++ b/lib/SCSI2SD/src/firmware/DaynaPort/DaynaPort.c
@@ -1,0 +1,267 @@
+/*
+ * DaynaPORT SCSI/Link personality.
+ *
+ * Copyright (c) 2023-2026 joshua stein <jcs@jcs.org>
+ * Copyright (c) 2026 Ingo Paschke <ipaschke@lpclabs.de>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * DaynaPORT personality: the sl003_io connecting sl003_core to the bus
+ * and the radio. Dispatched from scsi.c on S2S_CFG_NETWORK, like
+ * AmigaWIFI. INQUIRY and REQUEST SENSE are absent on purpose: scsi.c
+ * answers both before any personality runs; the byte-36 trailer is in
+ * inquiry.c.
+ */
+
+#ifdef BLUESCSI_NETWORK
+#include <string.h>
+#include "scsi.h"
+#include "scsi2sd_time.h"
+#include "scsiPhy.h"
+#include "config.h"
+#include "network.h"
+#include "sl003_core.h"
+
+#include "BlueSCSI_platform_network.h"
+#include "log.h"
+
+extern long ini_getl(const char *section, const char *key, long defval,
+                     const char *filename);
+#ifndef CONFIGFILE
+#define CONFIGFILE "bluescsi.ini"
+#endif
+
+static sl003_t g_sl003;
+static bool    g_ready;
+
+static void ensure_init(void)
+{
+	if (!g_ready) {
+		sl003_init(&g_sl003, (const uint8_t *)scsiDev.boardCfg.wifiMACAddress,
+		           &scsiNetworkInboundQueue);
+		/* DaynaPortGapHeaderUs / DaynaPortGapRecordUs ([SCSI] in
+		 * bluescsi.ini): inter-record pacing. Defaults match the real
+		 * device; software-timed blind hosts (SE/30, Plus) need them,
+		 * handshaked hosts can use 0. */
+		sl003_set_gaps(&g_sl003,
+			(uint16_t)ini_getl("SCSI", "DaynaPortGapHeaderUs",
+			                   SL003_GAP_AFTER_HEADER_US, CONFIGFILE),
+			(uint16_t)ini_getl("SCSI", "DaynaPortGapRecordUs",
+			                   SL003_GAP_AFTER_RECORD_US, CONFIGFILE));
+		g_ready = true;
+	}
+}
+
+/*
+ * Program the radio filter from the delivered multicast list; without
+ * this the CYW43 drops those frames (EtherTalk, mDNS, IPv6 ND). The
+ * platform has no removal call, so the filter only grows; addresses
+ * already installed are skipped to keep re-sent lists from filling the
+ * small table.
+ */
+static uint8_t g_filter[SL003_MULTICAST_MAX][6];
+static uint8_t g_filter_count;
+
+static void apply_multicast(void)
+{
+	uint8_t i, j;
+
+	for (i = 0; i < sl003_multicast_count(&g_sl003); i++) {
+		const uint8_t *a = sl003_multicast_addr(&g_sl003, i);
+
+		for (j = 0; j < g_filter_count; j++)
+			if (memcmp(g_filter[j], a, 6) == 0)
+				break;
+		if (j < g_filter_count)
+			continue;
+
+		platform_network_add_multicast_address((uint8_t *)a);
+		if (g_filter_count < SL003_MULTICAST_MAX)
+			memcpy(g_filter[g_filter_count++], a, 6);
+	}
+}
+
+/* Byte 36 of INQUIRY, delivered by inquiry.c's generic path. */
+uint8_t scsiNetworkInquiryStatus(void)
+{
+	ensure_init();
+	return (uint8_t)((sl003_enabled(&g_sl003) ? SL003_INQ_ENABLED : 0) |
+	                 (sl003_mode_set(&g_sl003) ? SL003_INQ_MODE_SET : 0));
+}
+
+/*
+ * Batch-depth histogram, diagnostics builds only
+ * (-DBLUESCSI_NETWORK_DEBUG=ON). Counts blind batches; polled READs
+ * report depth 0.
+ */
+#ifdef NETWORK_DEBUG_LOGGING
+#define DEPTH_BUCKETS 24
+static uint32_t g_depth_hist[DEPTH_BUCKETS];
+static uint32_t g_depth_reads;
+static uint16_t g_depth_max;
+
+static void depth_tally(uint16_t records)
+{
+	uint32_t half, run;
+	uint16_t i, median;
+
+	if (records >= DEPTH_BUCKETS)
+		g_depth_hist[DEPTH_BUCKETS - 1]++;
+	else
+		g_depth_hist[records]++;
+	if (records > g_depth_max)
+		g_depth_max = records;
+
+	if (++g_depth_reads % 512 != 0)
+		return;
+
+	half = g_depth_reads / 2;
+	run = 0;
+	median = 0;
+	for (i = 0; i < DEPTH_BUCKETS; i++) {
+		run += g_depth_hist[i];
+		if (run >= half) { median = i; break; }
+	}
+	LOGMSG_F("SL003 batch depth over %lu reads: median %u, max %u, "
+	         "empty %lu, 1 %lu, 2 %lu, 3 %lu, 4-7 %lu, 8+ %lu",
+	         (unsigned long)g_depth_reads, median, g_depth_max,
+	         (unsigned long)g_depth_hist[0], (unsigned long)g_depth_hist[1],
+	         (unsigned long)g_depth_hist[2], (unsigned long)g_depth_hist[3],
+	         (unsigned long)(g_depth_hist[4] + g_depth_hist[5] +
+	                         g_depth_hist[6] + g_depth_hist[7]),
+	         (unsigned long)(g_depth_reads - g_depth_hist[0] -
+	                         g_depth_hist[1] - g_depth_hist[2] -
+	                         g_depth_hist[3] - g_depth_hist[4] -
+	                         g_depth_hist[5] - g_depth_hist[6] -
+	                         g_depth_hist[7]));
+}
+#else
+#define depth_tally(records) ((void)0)
+#endif
+
+/*
+ * The sl003_io over the real bus. Data phases are entered lazily, on the
+ * first byte each direction moves.
+ *
+ * Do not poll the radio from emit: cyw43 work is a millisecond-scale SPI
+ * conversation and would run with the initiator waiting mid-phase.
+ */
+struct bus_io {
+	bool in_data_in;
+	bool in_data_out;
+	bool parity;
+};
+
+static bool bus_emit(void *ctx, const uint8_t *data, uint16_t len)
+{
+	struct bus_io *b = ctx;
+
+	if (scsiDev.resetFlag)
+		return false;
+	if (!b->in_data_in) {
+		scsiEnterPhase(DATA_IN);
+		b->in_data_in = true;
+	}
+	/* scsiWrite blocks; on return the bytes are on the bus and the
+	 * pointer (possibly into a ring slot) is finished with. */
+	scsiWrite(data, len);
+	return !scsiDev.resetFlag;
+}
+
+static bool bus_fetch(void *ctx, uint8_t *buf, uint16_t len)
+{
+	struct bus_io *b = ctx;
+	int parityError = 0;
+
+	if (scsiDev.resetFlag)
+		return false;
+	if (!b->in_data_out) {
+		scsiEnterPhase(DATA_OUT);
+		b->in_data_out = true;
+	}
+	scsiRead(buf, len, &parityError);
+	/* scsiRead returns without transferring once resetFlag is set;
+	 * treating that as data would transmit garbage or parse stale bytes
+	 * as a record length. */
+	if (scsiDev.resetFlag)
+		return false;
+	if (parityError) {
+		b->parity = true;
+		return false;
+	}
+	return true;
+}
+
+static void bus_gap(void *ctx, uint16_t us)
+{
+	(void)ctx;
+	if (us)
+		sleep_us(us);
+}
+
+static void bus_tx(void *ctx, const uint8_t *frame, uint16_t len)
+{
+	(void)ctx;
+	platform_network_send((uint8_t *)frame, len);
+}
+
+int scsiNetworkCommand(void)
+{
+	struct bus_io bus = { false, false, false };
+	const sl003_io io = { bus_emit, bus_fetch, bus_gap, bus_tx, &bus };
+	sl003_result r;
+
+	ensure_init();
+
+	if (scsiDev.cdb[0] == SCSI_NETWORK_WIFI_CMD)
+		return scsiNetworkWifiCommand();
+
+	/* Ring overflow drops feed the missed-packet counter. */
+	sl003_count_missed(&g_sl003, scsiNetworkMissed);
+	scsiNetworkMissed = 0;
+
+	r = sl003_handle(&g_sl003, scsiDev.cdb, &io);
+	scsiNetworkEnabled = sl003_enabled(&g_sl003);
+
+	if (scsiDev.cdb[0] == SL003_CMD_READ)
+		depth_tally(sl003_records_sent(&g_sl003));
+
+	/* Only when a list actually arrived (see sl003_multicast_take). */
+	if (sl003_multicast_take(&g_sl003))
+		apply_multicast();
+
+	if (bus.parity) {
+		scsiDev.status = CHECK_CONDITION;
+		scsiDev.target->sense.code = ABORTED_COMMAND;
+		scsiDev.target->sense.asc = SCSI_PARITY_ERROR;
+		scsiDev.phase = STATUS;
+		return 1;
+	}
+	if (r != SL003_OK) {
+		scsiDev.status = CHECK_CONDITION;
+		scsiDev.target->sense.code = ILLEGAL_REQUEST;
+		scsiDev.target->sense.asc = (r == SL003_CHECK_FIELD)
+			? INVALID_FIELD_IN_CDB
+			: INVALID_COMMAND_OPERATION_CODE;
+		scsiDev.phase = STATUS;
+		return 1;
+	}
+
+	scsiDev.status = GOOD;
+	scsiDev.phase = STATUS;
+	return 1;
+}
+
+#endif /* BLUESCSI_NETWORK */

--- a/lib/SCSI2SD/src/firmware/DaynaPort/DaynaPort.c
+++ b/lib/SCSI2SD/src/firmware/DaynaPort/DaynaPort.c
@@ -50,8 +50,11 @@ static bool    g_ready;
 static void ensure_init(void)
 {
 	if (!g_ready) {
+		/* scsiDev.data is the DATA OUT landing area, as it was for the
+		 * pre-rewrite handler; it is far larger than SL003_PKT_MAX and
+		 * idle whenever the core fetches. */
 		sl003_init(&g_sl003, (const uint8_t *)scsiDev.boardCfg.wifiMACAddress,
-		           &scsiNetworkInboundQueue);
+		           &scsiNetworkInboundQueue, scsiDev.data);
 		/* DaynaPortGapHeaderUs / DaynaPortGapRecordUs ([SCSI] in
 		 * bluescsi.ini): inter-record pacing. Defaults match the real
 		 * device; software-timed blind hosts (SE/30, Plus) need them,

--- a/lib/SCSI2SD/src/firmware/DaynaPort/DaynaPort.c
+++ b/lib/SCSI2SD/src/firmware/DaynaPort/DaynaPort.c
@@ -35,6 +35,7 @@
 #include "sl003_core.h"
 
 #include "BlueSCSI_platform_network.h"
+#include "hardware/sync.h"
 #include "log.h"
 
 extern long ini_getl(const char *section, const char *key, long defval,
@@ -156,7 +157,10 @@ static void depth_tally(uint16_t records)
  * first byte each direction moves.
  *
  * Do not poll the radio from emit: cyw43 work is a millisecond-scale SPI
- * conversation and would run with the initiator waiting mid-phase.
+ * conversation and would run with the initiator waiting mid-phase. The
+ * radio IRQ refills the ring instead (threadsafe-background arch), at no
+ * bus cost. That also means a batch is NOT bounded by ring depth; the
+ * bounds are the core's batch ceiling and the record cap.
  */
 struct bus_io {
 	bool in_data_in;
@@ -228,9 +232,16 @@ int scsiNetworkCommand(void)
 	if (scsiDev.cdb[0] == SCSI_NETWORK_WIFI_CMD)
 		return scsiNetworkWifiCommand();
 
-	/* Ring overflow drops feed the missed-packet counter. */
-	sl003_count_missed(&g_sl003, scsiNetworkMissed);
-	scsiNetworkMissed = 0;
+	/* Ring overflow drops feed the missed-packet counter. Read and clear
+	 * as one step: the producer increments from an IRQ, and a drop
+	 * landing between the two would be lost. */
+	{
+		uint32_t save = save_and_disable_interrupts();
+		uint32_t missed = scsiNetworkMissed;
+		scsiNetworkMissed = 0;
+		restore_interrupts(save);
+		sl003_count_missed(&g_sl003, missed);
+	}
 
 	r = sl003_handle(&g_sl003, scsiDev.cdb, &io);
 	scsiNetworkEnabled = sl003_enabled(&g_sl003);

--- a/lib/SCSI2SD/src/firmware/DaynaPort/DaynaPort.c
+++ b/lib/SCSI2SD/src/firmware/DaynaPort/DaynaPort.c
@@ -99,7 +99,8 @@ uint8_t scsiNetworkInquiryStatus(void)
 {
 	ensure_init();
 	return (uint8_t)((sl003_enabled(&g_sl003) ? SL003_INQ_ENABLED : 0) |
-	                 (sl003_mode_set(&g_sl003) ? SL003_INQ_MODE_SET : 0));
+	                 (sl003_mode_set(&g_sl003) ? SL003_INQ_MODE_SET : 0) |
+	                 SL003_INQ_BATCH_BOUNDED);
 }
 
 /*

--- a/lib/SCSI2SD/src/firmware/DaynaPort/sl003_core.c
+++ b/lib/SCSI2SD/src/firmware/DaynaPort/sl003_core.c
@@ -1,0 +1,423 @@
+/*
+ * Copyright (c) 2026 Ingo Paschke <ipaschke@lpclabs.de>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/* SL003 SCSI/Link protocol core.
+ *
+ * Behaviour and structure follow the Dayna SL003 v2.0 firmware
+ * disassembly; ROM addresses appear in comments.
+ */
+#ifdef BLUESCSI_NETWORK
+#include <string.h>
+#include "sl003_core.h"
+
+void sl003_init(sl003_t *s, const uint8_t mac[6],
+                struct scsiNetworkPacketQueue *ring)
+{
+    memset(s, 0, sizeof *s);
+    memcpy(s->mac, mac, 6);
+    s->rx = ring;
+    s->gap_header_us = SL003_GAP_AFTER_HEADER_US;
+    s->gap_record_us = SL003_GAP_AFTER_RECORD_US;
+}
+
+void sl003_set_gaps(sl003_t *s, uint16_t header_us, uint16_t record_us)
+{
+    s->gap_header_us = header_us;
+    s->gap_record_us = record_us;
+}
+
+uint16_t sl003_rx_count(const sl003_t *s)
+{
+    return (uint16_t)((s->rx->writeIndex - s->rx->readIndex
+                       + NETWORK_PACKET_QUEUE_SIZE) % NETWORK_PACKET_QUEUE_SIZE);
+}
+
+uint16_t sl003_records_sent(const sl003_t *s) { return s->records_sent; }
+bool     sl003_enabled(const sl003_t *s)      { return s->enabled; }
+bool     sl003_mode_set(const sl003_t *s)     { return s->mode_set; }
+
+void sl003_count_missed(sl003_t *s, uint32_t n) { s->ctr_missed_seen += n; }
+void sl003_count_crc(sl003_t *s)     { s->ctr_crc++; }
+void sl003_count_align(sl003_t *s)   { s->ctr_align++; }
+void sl003_count_overrun(sl003_t *s) { s->ctr_overrun++; }
+
+const uint8_t *sl003_mac(const sl003_t *s) { return s->mac; }
+
+bool sl003_multicast_take(sl003_t *s)
+{
+    bool d = s->multicast_dirty;
+    s->multicast_dirty = false;
+    return d;
+}
+
+uint8_t        sl003_multicast_count(const sl003_t *s) { return s->multicast_count; }
+const uint8_t *sl003_multicast_addr(const sl003_t *s, uint8_t i)
+{
+    return s->multicast[i];
+}
+
+/* Until 0x0e enables the interface only these four are accepted (1c60). */
+static bool allowed_while_disabled(uint8_t op)
+{
+    return op == SL003_CMD_TEST_UNIT_READY ||
+           op == SL003_CMD_REQUEST_SENSE   ||
+           op == SL003_CMD_ENABLE          ||
+           op == SL003_CMD_INQUIRY;
+}
+
+static uint8_t rx_next_index(const sl003_t *s)
+{
+    return (uint8_t)((s->rx->readIndex + 1) % NETWORK_PACKET_QUEUE_SIZE);
+}
+
+/* [len hi][len lo][0][0][0][flags]. len is the whole frame including its
+ * FCS, never the clipped amount (0x0e8a). */
+static void build_record_header(const sl003_t *s, uint8_t hdr[6],
+                                uint16_t len, bool more, bool runt)
+{
+    memset(hdr, 0, SL003_RECORD_HDR_LEN);
+    hdr[0] = (uint8_t)(len >> 8);
+    hdr[1] = (uint8_t)len;
+    hdr[5] = (uint8_t)((more ? SL003_FLAG_MORE : 0) |
+                       ((runt && s->mode_set) ? SL003_FLAG_RUNT : 0));
+}
+
+/*
+ * How many bytes we may ask fetch() to deposit in wbuf. CDB[3..4] is
+ * sixteen bits of whatever the host felt like sending, and fetch fills
+ * exactly the count we hand it -- an unclamped value is a buffer overflow
+ * we asked for.
+ */
+static uint16_t clamp_want(uint16_t want)
+{
+    return want > SL003_PKT_MAX ? (uint16_t)SL003_PKT_MAX : want;
+}
+
+/* ------------------------------------------------------------------ */
+/* READ(6), polled: exactly one record, never a terminator (0x0d77).   */
+/* ------------------------------------------------------------------ */
+
+static void read_polled(sl003_t *s, const uint8_t cdb[6], uint16_t alloc,
+                        const sl003_io *io)
+{
+    uint8_t  hdr[SL003_RECORD_HDR_LEN];
+    uint16_t len, off, cap, send;
+
+    if (sl003_rx_count(s) == 0) {
+        /* The empty-queue answer is a real six-byte record of length zero. */
+        build_record_header(s, hdr, 0, false, false);
+        io->emit(io->ctx, hdr, SL003_RECORD_HDR_LEN);
+        return;
+    }
+
+    len = s->rx->sizes[s->rx->readIndex];
+    /* CDB[1..2] is a byte offset into the head packet: the stateless
+     * peek/resume the ROM supports at 0x0e05-0x0f17. */
+    off = (uint16_t)((cdb[1] << 8) | cdb[2]);
+    if (off > len) off = len;
+    cap  = alloc > SL003_RECORD_HDR_LEN
+         ? (uint16_t)(alloc - SL003_RECORD_HDR_LEN) : 0;
+    send = (uint16_t)(len - off);
+    if (send > cap) send = cap;
+
+    build_record_header(s, hdr, len,
+                        rx_next_index(s) != s->rx->writeIndex, len < 60);
+    if (!io->emit(io->ctx, hdr, SL003_RECORD_HDR_LEN))
+        return;                         /* bus gone; the packet stays queued */
+
+    /*
+     * An allocation too small to carry payload is a pure peek: the host
+     * sees the header and the packet stays queued, whatever CDB[5] says.
+     */
+    if (alloc <= SL003_RECORD_HDR_LEN)
+        return;
+
+    io->gap(io->ctx, s->gap_header_us);
+
+    if (send) {
+        if (!io->emit(io->ctx, s->rx->packets[s->rx->readIndex] + off, send))
+            return;                     /* bus gone mid-payload: keep it */
+    }
+
+    /* Dequeue iff this read finished the packet, or the host asked for the
+     * remainder to be dropped (CDB[5] != 0). emit has returned, so the
+     * slot is no longer being transmitted from and may go back. */
+    if ((uint16_t)(off + send) >= len || cdb[5] != 0)
+        s->rx->readIndex = rx_next_index(s);
+}
+
+/* ------------------------------------------------------------------ */
+/* READ(6), blind: a stream of records (0x0bfc-0x0d6a).                */
+/* ------------------------------------------------------------------ */
+
+static void read_blind(sl003_t *s, uint16_t alloc, const sl003_io *io)
+{
+    uint8_t  hdr[SL003_RECORD_HDR_LEN];
+    uint32_t batch_bytes = 0;
+    uint16_t limit;
+
+    /*
+     * Batch bound. The ROM has none: the record cap is its only limit and
+     * the allocation clips each record, not the total (0x0cb7-0x0cf2).
+     * An allocation of two or more maximum records is taken as the host's
+     * buffer size and bounds the whole batch; ALLOC 1524 (all known Mac
+     * drivers) streams unbounded as the ROM does. Fixed-length initiators
+     * with no residual reporting (Atari SCSI_In) need the bound.
+     */
+    limit = 0;
+    if (alloc >= 2 * SL003_MAX_RECORD)
+        limit = alloc;
+
+    for (;;) {
+        uint16_t len, cap, send;
+        bool more;
+
+        if (s->records_sent >= SL003_BLIND_RECORD_CAP) {
+            /* Cap reached while more is pending: close the batch with a
+             * zero-length record so the host knows to read again (0x0c1c). */
+            build_record_header(s, hdr, 0, false, false);
+            io->emit(io->ctx, hdr, SL003_RECORD_HDR_LEN);
+            return;
+        }
+
+        if (sl003_rx_count(s) == 0) {
+            /* Nothing left. If we already sent a record its flag said so
+             * and the host has stopped; only an empty batch owes a reply. */
+            if (s->records_sent > 0)
+                return;
+            build_record_header(s, hdr, 0, false, false);
+            io->emit(io->ctx, hdr, SL003_RECORD_HDR_LEN);
+            return;
+        }
+
+        len = s->rx->sizes[s->rx->readIndex];
+
+        /*
+         * Tested BEFORE adding the record; testing after would overrun
+         * the host's transfer by up to one record. Redundant with the
+         * more-flag suppression below, kept as a backstop. Never applies
+         * to the first record: the per-record clip fits it.
+         */
+        if (limit && s->records_sent > 0
+         && batch_bytes + len + SL003_RECORD_HDR_LEN > limit)
+            return;
+
+        cap  = alloc > SL003_RECORD_HDR_LEN
+             ? (uint16_t)(alloc - SL003_RECORD_HDR_LEN) : 0;
+        send = len < cap ? len : cap;
+
+        /* Counts the whole record, not the clipped payload. Clipping and
+         * a limit cannot coexist (clip needs alloc < 1 record, the limit
+         * needs >= 2), and overstating is the safe direction anyway. */
+        batch_bytes += (uint32_t)len + SL003_RECORD_HDR_LEN;
+
+        /* Read live from the queue, so a frame arriving mid-batch is seen
+         * (0x0ca6). */
+        more = rx_next_index(s) != s->rx->writeIndex;
+
+        /* The flag is a promise of another record in THIS batch, so check
+         * the record actually queued next; its length is fixed and the
+         * producer can only append behind it. */
+        if (more && limit) {
+            uint16_t nlen = s->rx->sizes[rx_next_index(s)];
+            if (batch_bytes + nlen + SL003_RECORD_HDR_LEN > limit)
+                more = false;
+        }
+
+        build_record_header(s, hdr, len, more, len < 60);
+        if (!io->emit(io->ctx, hdr, SL003_RECORD_HDR_LEN))
+            return;
+        io->gap(io->ctx, s->gap_header_us);
+
+        if (send) {
+            if (!io->emit(io->ctx,
+                          s->rx->packets[s->rx->readIndex], send)) {
+                s->rx->readIndex = rx_next_index(s);   /* spent either way */
+                return;
+            }
+            io->gap(io->ctx, s->gap_record_us);
+        }
+
+        /* emit has returned; the slot may go back to the producer. */
+        s->rx->readIndex = rx_next_index(s);
+        s->records_sent++;
+
+        if (!more)
+            return;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* READ MAC + statistics (0x09): 22 bytes, counters read-and-clear.    */
+/* ------------------------------------------------------------------ */
+
+/* The Z180 stored these little-endian and the ROM hands them out untouched,
+ * which is why the Dayna driver runs each through swaplong. Byte-swapping
+ * them here would silently break that driver. */
+static void put_le32(uint8_t *p, uint32_t v)
+{
+    p[0] = (uint8_t)v;
+    p[1] = (uint8_t)(v >> 8);
+    p[2] = (uint8_t)(v >> 16);
+    p[3] = (uint8_t)(v >> 24);
+}
+
+static void read_stats(sl003_t *s, uint16_t alloc, const sl003_io *io)
+{
+    uint8_t  buf[SL003_STATS_LEN];
+    uint16_t len;
+
+    memcpy(buf, s->mac, 6);
+    put_le32(buf + 6,  s->ctr_missed_seen);
+    put_le32(buf + 10, s->ctr_crc);
+    put_le32(buf + 14, s->ctr_align);
+    put_le32(buf + 18, s->ctr_overrun);
+    /* Cleared on every 0x09, regardless of how much the host takes: the
+     * ROM's counters are read-and-clear. */
+    s->ctr_missed_seen = s->ctr_crc = s->ctr_align = s->ctr_overrun = 0;
+
+    len = alloc < SL003_STATS_LEN ? alloc : SL003_STATS_LEN;
+    if (len)
+        io->emit(io->ctx, buf, len);
+}
+
+/* ------------------------------------------------------------------ */
+/* WRITE(6): raw packet or record stream, by CDB[5] bit 7 (0x1281).    */
+/* ------------------------------------------------------------------ */
+
+static void write_stream(sl003_t *s, const sl003_io *io)
+{
+    /* [len(2)][pad(2)][payload] repeated; a zero-length header ends the
+     * stream and CDB[3..4] is ignored (0x1294). */
+    for (;;) {
+        uint16_t reclen;
+
+        if (!io->fetch(io->ctx, s->wbuf, 4))
+            return;                     /* bus gone; nothing leaks */
+        reclen = (uint16_t)((s->wbuf[0] << 8) | s->wbuf[1]);
+        if (reclen == 0)
+            return;                     /* terminator */
+        if (reclen > SL003_PKT_MAX)
+            return;                     /* absurd length: abandon the stream */
+        if (!io->fetch(io->ctx, s->wbuf, reclen))
+            return;
+        io->tx(io->ctx, s->wbuf, reclen);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Dispatch (0x0b5e)                                                   */
+/* ------------------------------------------------------------------ */
+
+sl003_result sl003_handle(sl003_t *s, const uint8_t cdb[6],
+                          const sl003_io *io)
+{
+    uint16_t alloc = (uint16_t)((cdb[3] << 8) | cdb[4]);
+
+    if (!s->enabled && !allowed_while_disabled(cdb[0]))
+        return SL003_CHECK_CONDITION;
+
+    switch (cdb[0]) {
+    case SL003_CMD_TEST_UNIT_READY:
+        return SL003_OK;
+
+    case SL003_CMD_INQUIRY:
+        /* Answered by s2s_scsiInquiry before this personality runs; the
+         * byte-36 status trailer lives in inquiry.c. */
+        return SL003_OK;
+
+    case SL003_CMD_REQUEST_SENSE:
+        /* Served by s2s_scsiRequestSense from scsiDev.target->sense before
+         * a personality is ever reached. Accepted here only so the
+         * disabled gate agrees with what the host actually sees. */
+        return SL003_OK;
+
+    case SL003_CMD_ENABLE:
+        if (cdb[5] & SL003_ENABLE_BIT) {
+            s->enabled = true;
+            /* Drop what is queued by moving OUR index up to the
+             * producer's. Writing writeIndex here would race a producer
+             * that runs concurrently with SCSI commands. */
+            s->rx->readIndex = s->rx->writeIndex;
+        } else {
+            s->enabled = false;
+        }
+        return SL003_OK;
+
+    case SL003_CMD_READ_STATS:
+        read_stats(s, alloc, io);
+        return SL003_OK;
+
+    case SL003_CMD_SET_MODE:
+        /* SET MAC (bit 6) is refused: the radio cannot change its receive
+         * address, and accepting would report a MAC via 0x09 that never
+         * receives. Refused before any DATA OUT; a combined mode+addr CDB
+         * is refused whole. Wire a real implementation here if the
+         * platform ever grows one. */
+        if (cdb[5] & SL003_SETMODE_ADDR_BIT)
+            return SL003_CHECK_FIELD;
+        if (cdb[5] & SL003_SETMODE_MODE_BIT) {
+            s->mode     = cdb[4];
+            s->mode_set = true;
+        }
+        return SL003_OK;
+
+    case SL003_CMD_ADD_MULTICAST: {
+        /* 6-byte strides over the whole list, not just the first address:
+         * the real device walks it all and rebuilds its hash filter. */
+        uint16_t want = clamp_want(alloc);
+        uint16_t off;
+        if (want == 0)
+            return SL003_OK;
+        if (!io->fetch(io->ctx, s->wbuf, want))
+            return SL003_OK;
+        s->multicast_count = 0;
+        for (off = 0; off + 6 <= want &&
+                      s->multicast_count < SL003_MULTICAST_MAX; off += 6) {
+            memcpy(s->multicast[s->multicast_count], s->wbuf + off, 6);
+            s->multicast_count++;
+        }
+        s->multicast_dirty = true;
+        return SL003_OK;
+    }
+
+    case SL003_CMD_WRITE:
+        /* Nonzero CDB[1..2] is rejected by the real device (0x1281). */
+        if (cdb[1] != 0 || cdb[2] != 0)
+            return SL003_CHECK_FIELD;
+        if (cdb[5] & SL003_WRITE_STREAM_BIT) {
+            write_stream(s, io);
+        } else {
+            uint16_t want = clamp_want(alloc);
+            if (want && io->fetch(io->ctx, s->wbuf, want))
+                io->tx(io->ctx, s->wbuf, want);
+        }
+        return SL003_OK;
+
+    case SL003_CMD_READ:
+        s->records_sent = 0;
+        if (cdb[5] & SL003_READ_BLIND_BIT)
+            read_blind(s, alloc, io);
+        else
+            read_polled(s, cdb, alloc, io);
+        return SL003_OK;
+
+    default:
+        return SL003_CHECK_CONDITION;
+    }
+}
+
+#endif /* BLUESCSI_NETWORK */

--- a/lib/SCSI2SD/src/firmware/DaynaPort/sl003_core.c
+++ b/lib/SCSI2SD/src/firmware/DaynaPort/sl003_core.c
@@ -163,7 +163,8 @@ static void read_polled(sl003_t *s, const uint8_t cdb[6], uint16_t alloc,
 /* READ(6), blind: a stream of records (0x0bfc-0x0d6a).                */
 /* ------------------------------------------------------------------ */
 
-static void read_blind(sl003_t *s, uint16_t alloc, const sl003_io *io)
+static void read_blind(sl003_t *s, const uint8_t cdb[6], uint16_t alloc,
+                       const sl003_io *io)
 {
     uint8_t  hdr[SL003_RECORD_HDR_LEN];
     uint32_t batch_bytes = 0;
@@ -172,13 +173,14 @@ static void read_blind(sl003_t *s, uint16_t alloc, const sl003_io *io)
     /*
      * Batch bound. The ROM has none: the record cap is its only limit and
      * the allocation clips each record, not the total (0x0cb7-0x0cf2).
-     * An allocation of two or more maximum records is taken as the host's
-     * buffer size and bounds the whole batch; ALLOC 1524 (all known Mac
-     * drivers) streams unbounded as the ROM does. Fixed-length initiators
-     * with no residual reporting (Atari SCSI_In) need the bound.
+     * Bounded only when the host asks for it with SL003_READ_BOUNDED_BIT;
+     * hosts learn the bit is honored from the INQUIRY capability bit.
+     * Without the bit every allocation streams unbounded, exactly as the
+     * ROM does. Fixed-length initiators with no residual reporting
+     * (Atari SCSI_In) must set the bit.
      */
     limit = 0;
-    if (alloc >= 2 * SL003_MAX_RECORD)
+    if (cdb[5] & SL003_READ_BOUNDED_BIT)
         limit = alloc;
 
     for (;;) {
@@ -219,9 +221,10 @@ static void read_blind(sl003_t *s, uint16_t alloc, const sl003_io *io)
              ? (uint16_t)(alloc - SL003_RECORD_HDR_LEN) : 0;
         send = len < cap ? len : cap;
 
-        /* Counts the whole record, not the clipped payload. Clipping and
-         * a limit cannot coexist (clip needs alloc < 1 record, the limit
-         * needs >= 2), and overstating is the safe direction anyway. */
+        /* Counts the whole record, not the clipped payload. With the
+         * bounded bit and an allocation under one record both clip and
+         * limit apply; overstating the spent budget is the safe
+         * direction (the batch stops sooner, never later). */
         batch_bytes += (uint32_t)len + SL003_RECORD_HDR_LEN;
 
         /* Read live from the queue, so a frame arriving mid-batch is seen
@@ -410,7 +413,7 @@ sl003_result sl003_handle(sl003_t *s, const uint8_t cdb[6],
     case SL003_CMD_READ:
         s->records_sent = 0;
         if (cdb[5] & SL003_READ_BLIND_BIT)
-            read_blind(s, alloc, io);
+            read_blind(s, cdb, alloc, io);
         else
             read_polled(s, cdb, alloc, io);
         return SL003_OK;

--- a/lib/SCSI2SD/src/firmware/DaynaPort/sl003_core.c
+++ b/lib/SCSI2SD/src/firmware/DaynaPort/sl003_core.c
@@ -24,11 +24,12 @@
 #include "sl003_core.h"
 
 void sl003_init(sl003_t *s, const uint8_t mac[6],
-                struct scsiNetworkPacketQueue *ring)
+                struct scsiNetworkPacketQueue *ring, uint8_t *wbuf)
 {
     memset(s, 0, sizeof *s);
     memcpy(s->mac, mac, 6);
     s->rx = ring;
+    s->wbuf = wbuf;
     s->gap_header_us = SL003_GAP_AFTER_HEADER_US;
     s->gap_record_us = SL003_GAP_AFTER_RECORD_US;
 }

--- a/lib/SCSI2SD/src/firmware/DaynaPort/sl003_core.c
+++ b/lib/SCSI2SD/src/firmware/DaynaPort/sl003_core.c
@@ -24,12 +24,14 @@
 #include "sl003_core.h"
 
 void sl003_init(sl003_t *s, const uint8_t mac[6],
-                struct scsiNetworkPacketQueue *ring, uint8_t *wbuf)
+                struct scsiNetworkPacketQueue *ring,
+                uint8_t *wbuf, uint32_t wbuf_len)
 {
     memset(s, 0, sizeof *s);
     memcpy(s->mac, mac, 6);
     s->rx = ring;
     s->wbuf = wbuf;
+    s->wbuf_len = wbuf_len;
     s->gap_header_us = SL003_GAP_AFTER_HEADER_US;
     s->gap_record_us = SL003_GAP_AFTER_RECORD_US;
 }
@@ -134,29 +136,50 @@ static void read_polled(sl003_t *s, const uint8_t cdb[6], uint16_t alloc,
     send = (uint16_t)(len - off);
     if (send > cap) send = cap;
 
-    build_record_header(s, hdr, len,
-                        rx_next_index(s) != s->rx->writeIndex, len < 60);
-    if (!io->emit(io->ctx, hdr, SL003_RECORD_HDR_LEN))
-        return;                         /* bus gone; the packet stays queued */
-
     /*
      * An allocation too small to carry payload is a pure peek: the host
-     * sees the header and the packet stays queued, whatever CDB[5] says.
+     * sees the header alone and the packet stays queued, whatever
+     * CDB[5] says.
      */
-    if (alloc <= SL003_RECORD_HDR_LEN)
+    if (alloc <= SL003_RECORD_HDR_LEN) {
+        build_record_header(s, hdr, len,
+                            rx_next_index(s) != s->rx->writeIndex, len < 60);
+        io->emit(io->ctx, hdr, SL003_RECORD_HDR_LEN);
         return;
-
-    io->gap(io->ctx, s->gap_header_us);
-
-    if (send) {
-        if (!io->emit(io->ctx, s->rx->packets[s->rx->readIndex] + off, send))
-            return;                     /* bus gone mid-payload: keep it */
     }
 
-    /* Dequeue iff this read finished the packet, or the host asked for the
-     * remainder to be dropped (CDB[5] != 0). emit has returned, so the
-     * slot is no longer being transmitted from and may go back. */
-    if ((uint16_t)(off + send) >= len || cdb[5] != 0)
+    if (cdb[5] & SL003_READ_SEAMLESS_BIT) {
+        /* Host opted in: header and payload staged into wbuf and sent
+         * as ONE emit (see read_blind: seam pauses trigger a host-side
+         * injection bug). wbuf is the caller's data-phase scratch and
+         * is idle here, READ having no DATA OUT. */
+        build_record_header(s, s->wbuf, len,
+                            rx_next_index(s) != s->rx->writeIndex, len < 60);
+        memcpy(s->wbuf + SL003_RECORD_HDR_LEN,
+               s->rx->packets[s->rx->readIndex] + off, send);
+        if (!io->emit(io->ctx, s->wbuf,
+                      (uint16_t)(SL003_RECORD_HDR_LEN + send)))
+            return;                     /* bus gone: keep the packet */
+    } else {
+        build_record_header(s, hdr, len,
+                            rx_next_index(s) != s->rx->writeIndex, len < 60);
+        if (!io->emit(io->ctx, hdr, SL003_RECORD_HDR_LEN))
+            return;                     /* bus gone; the packet stays queued */
+        io->gap(io->ctx, s->gap_header_us);
+        if (send) {
+            if (!io->emit(io->ctx,
+                          s->rx->packets[s->rx->readIndex] + off, send))
+                return;                 /* bus gone mid-payload: keep it */
+        }
+    }
+
+    /* Dequeue iff this read finished the packet, or the host asked for
+     * the remainder to be dropped (any ROM-defined CDB[5] bit set; the
+     * seamless bit is an emission request, not a drop request, and
+     * must not count). emit has returned, so the slot is no longer
+     * being transmitted from and may go back. */
+    if ((uint16_t)(off + send) >= len
+     || (cdb[5] & (uint8_t)~SL003_READ_SEAMLESS_BIT) != 0)
         s->rx->readIndex = rx_next_index(s);
 }
 
@@ -164,12 +187,37 @@ static void read_polled(sl003_t *s, const uint8_t cdb[6], uint16_t alloc,
 /* READ(6), blind: a stream of records (0x0bfc-0x0d6a).                */
 /* ------------------------------------------------------------------ */
 
+/*
+ * Seamless staging. The host's promise for a blind transfer is a data
+ * phase with no REQ pause anywhere in it, and one emit per record does
+ * not keep it: the pause BETWEEN records is a stall too, and the
+ * Quadra-era SCSI Manager 4.3 SIM fabricates two bytes at any stall the
+ * host did not declare. So a seamless batch accumulates whole and goes
+ * out as ONE transfer, never split: a batch that would outgrow the
+ * staging area ends early instead, which blind mode permits the device
+ * anywhere, and the remaining records lead the next command.
+ */
+static bool stage_flush(sl003_t *s, const sl003_io *io, uint32_t *staged)
+{
+    uint32_t n = *staged;
+
+    *staged = 0;
+    if (n == 0)
+        return true;
+    return io->emit(io->ctx, s->wbuf, (uint16_t)n);
+}
+
 static void read_blind(sl003_t *s, const uint8_t cdb[6], uint16_t alloc,
                        const sl003_io *io)
 {
     uint8_t  hdr[SL003_RECORD_HDR_LEN];
-    uint32_t batch_bytes = 0;
-    uint16_t limit;
+    uint32_t sent = 0;                  /* bytes actually emitted so far */
+    uint32_t staged = 0;
+    bool     seamless = (cdb[5] & SL003_READ_SEAMLESS_BIT) != 0;
+    /* One transfer is one emit, and emit counts in 16 bits. */
+    uint32_t stage_cap = s->wbuf_len > 0xFFFF ? 0xFFFF : s->wbuf_len;
+    uint16_t cap;
+    bool     bounded;
 
     /*
      * Batch bound. The ROM has none: the record cap is its only limit and
@@ -180,88 +228,169 @@ static void read_blind(sl003_t *s, const uint8_t cdb[6], uint16_t alloc,
      * ROM does. Fixed-length initiators with no residual reporting
      * (Atari SCSI_In) must set the bit.
      */
-    limit = 0;
-    if (cdb[5] & SL003_READ_BOUNDED_BIT)
-        limit = alloc;
+    bounded = (cdb[5] & SL003_READ_BOUNDED_BIT) != 0;
+
+    /* A bounded batch never exceeds alloc, so with no room for even one
+     * header there is nothing that can be said. */
+    if (bounded && alloc < SL003_RECORD_HDR_LEN)
+        return;
+
+    /*
+     * Per-record clip, the ROM's: the allocation bounds one record, and
+     * the batch bound below is what keeps the total inside it. Taking
+     * the terminator's reserve off this as well would clip a full-size
+     * record while its header still declared the full length, and the
+     * host's walk would run off the end of it.
+     */
+    cap = alloc > SL003_RECORD_HDR_LEN
+        ? (uint16_t)(alloc - SL003_RECORD_HDR_LEN) : 0;
 
     for (;;) {
-        uint16_t len, cap, send;
+        uint16_t len, send;
         bool more;
 
         if (s->records_sent >= SL003_BLIND_RECORD_CAP) {
+            if (bounded)
+                goto term;
             /* Cap reached while more is pending: close the batch with a
              * zero-length record so the host knows to read again (0x0c1c). */
-            build_record_header(s, hdr, 0, false, false);
-            io->emit(io->ctx, hdr, SL003_RECORD_HDR_LEN);
-            return;
+            goto close_empty;
         }
 
         if (sl003_rx_count(s) == 0) {
             /* Nothing left. If we already sent a record its flag said so
-             * and the host has stopped; only an empty batch owes a reply. */
+             * and the host has stopped; only an empty batch owes a reply.
+             * Identical in bounded mode: a drained queue ends the batch
+             * the ROM way, no terminator. */
             if (s->records_sent > 0)
-                return;
-            build_record_header(s, hdr, 0, false, false);
-            io->emit(io->ctx, hdr, SL003_RECORD_HDR_LEN);
-            return;
+                goto done;
+            goto close_empty;
         }
 
         len = s->rx->sizes[s->rx->readIndex];
 
         /*
-         * Tested BEFORE adding the record; testing after would overrun
-         * the host's transfer by up to one record. Redundant with the
-         * more-flag suppression below, kept as a backstop. Never applies
-         * to the first record: the per-record clip fits it.
+         * The batch bound, tested BEFORE adding the record: testing
+         * after would overrun the host's transfer by up to one record.
+         * Only whole records join a bounded batch, so the full length
+         * is tested, not the clipped one, and one header is reserved
+         * so the closing terminator always fits behind the records it
+         * closes. Never applies to the first record, which the
+         * per-record clip already fits; only there can the reserve go
+         * unmet, when that record fills the whole allocation.
          */
-        if (limit && s->records_sent > 0
-         && batch_bytes + len + SL003_RECORD_HDR_LEN > limit)
-            return;
+        if (bounded && s->records_sent > 0
+         && sent + 2 * SL003_RECORD_HDR_LEN + len > alloc)
+            goto term;
 
-        cap  = alloc > SL003_RECORD_HDR_LEN
-             ? (uint16_t)(alloc - SL003_RECORD_HDR_LEN) : 0;
         send = len < cap ? len : cap;
-
-        /* Counts the whole record, not the clipped payload. With the
-         * bounded bit and an allocation under one record both clip and
-         * limit apply; overstating the spent budget is the safe
-         * direction (the batch stops sooner, never later). */
-        batch_bytes += (uint32_t)len + SL003_RECORD_HDR_LEN;
 
         /* Read live from the queue, so a frame arriving mid-batch is seen
          * (0x0ca6). */
         more = rx_next_index(s) != s->rx->writeIndex;
 
-        /* The flag is a promise of another record in THIS batch, so check
-         * the record actually queued next; its length is fixed and the
-         * producer can only append behind it. */
-        if (more && limit) {
-            uint16_t nlen = s->rx->sizes[rx_next_index(s)];
-            if (batch_bytes + nlen + SL003_RECORD_HDR_LEN > limit)
-                more = false;
-        }
+        if (seamless) {
+            /* Append to the batch; it leaves as one transfer, ALWAYS:
+             * a flush mid-batch would be the very stall the bit asks
+             * to remove. A record that will not fit the staging area
+             * (with the closing record's reserve) ends the batch
+             * instead -- blind mode lets the device end a batch
+             * anywhere, and the record leads the next one. Bounded
+             * batches end with their depth-carrying terminator. */
+            uint32_t need = (uint32_t)SL003_RECORD_HDR_LEN + send;
 
-        build_record_header(s, hdr, len, more, len < 60);
-        if (!io->emit(io->ctx, hdr, SL003_RECORD_HDR_LEN))
-            return;
-        io->gap(io->ctx, s->gap_header_us);
-
-        if (send) {
-            if (!io->emit(io->ctx,
-                          s->rx->packets[s->rx->readIndex], send)) {
-                s->rx->readIndex = rx_next_index(s);   /* spent either way */
-                return;
+            if (s->records_sent > 0
+             && staged + need + SL003_RECORD_HDR_LEN > stage_cap) {
+                if (bounded)
+                    goto term;
+                goto close_empty;
             }
-            io->gap(io->ctx, s->gap_record_us);
+            if (need > stage_cap) {
+                /* Caller under the documented wbuf minimum. Clip the
+                 * first record rather than overflow; the header still
+                 * declares the full length, as the ROM's own alloc
+                 * clip does. */
+                send = stage_cap > SL003_RECORD_HDR_LEN
+                     ? (uint16_t)(stage_cap - SL003_RECORD_HDR_LEN) : 0;
+                need = (uint32_t)SL003_RECORD_HDR_LEN + send;
+            }
+            build_record_header(s, s->wbuf + staged, len, more, len < 60);
+            memcpy(s->wbuf + staged + SL003_RECORD_HDR_LEN,
+                   s->rx->packets[s->rx->readIndex], send);
+            staged += need;
+        } else {
+            /* Classic timing: split emit with the ROM's gaps, which
+             * software-timed hosts (Plus, SE/30) calibrated their
+             * blind loops against. */
+            build_record_header(s, hdr, len, more, len < 60);
+            if (!io->emit(io->ctx, hdr, SL003_RECORD_HDR_LEN))
+                return;
+            io->gap(io->ctx, s->gap_header_us);
+            if (send) {
+                if (!io->emit(io->ctx,
+                              s->rx->packets[s->rx->readIndex], send)) {
+                    s->rx->readIndex = rx_next_index(s);
+                    return;
+                }
+                io->gap(io->ctx, s->gap_record_us);
+            }
+            /* Contiguous-emission hosts are hardware-handshaked and
+             * get no pacing gaps at all: one gap configuration then
+             * serves every machine on a shared card. */
         }
 
-        /* emit has returned; the slot may go back to the producer. */
+        /* The slot may go back to the producer: emit has returned, or
+         * in a staged batch the bytes are copied out of it. */
         s->rx->readIndex = rx_next_index(s);
         s->records_sent++;
+        sent += (uint32_t)SL003_RECORD_HDR_LEN + send;
 
         if (!more)
-            return;
+            goto done;
     }
+
+term:
+    /* Budget reached with records still queued: end the batch the way
+     * the ROM ends one at its record cap -- the last record kept its
+     * truthful more-flag, and this zero-length terminator says the
+     * batch ends anyway. Byte 2 reports the queue depth (records,
+     * clamped to 255) for adaptive pacing; hosts that ignore it see
+     * ROM behavior exactly. */
+    {
+        uint16_t q = sl003_rx_count(s);
+
+        build_record_header(s, hdr, 0, q > 0, false);
+        hdr[2] = q > 255 ? 255 : (uint8_t)q;
+        goto close;
+    }
+
+close_empty:
+    build_record_header(s, hdr, 0, false, false);
+
+close:
+    /* Reached only when a first record filled the whole allocation:
+     * the allocation comes first, and the batch ends on that record's
+     * more-flag with just the depth hint lost. Every later record was
+     * admitted with the terminator's reserve, so its room is
+     * guaranteed. */
+    if (bounded && sent + SL003_RECORD_HDR_LEN > alloc)
+        goto done;
+
+    /* The closing record rides out with the batch it ends: appended
+     * when there is room, otherwise after a flush. */
+    if (seamless) {
+        if (staged + SL003_RECORD_HDR_LEN > stage_cap
+         && !stage_flush(s, io, &staged))
+            return;
+        memcpy(s->wbuf + staged, hdr, SL003_RECORD_HDR_LEN);
+        staged += SL003_RECORD_HDR_LEN;
+    } else {
+        io->emit(io->ctx, hdr, SL003_RECORD_HDR_LEN);
+    }
+
+done:
+    if (seamless)
+        stage_flush(s, io, &staged);
 }
 
 /* ------------------------------------------------------------------ */

--- a/lib/SCSI2SD/src/firmware/DaynaPort/sl003_core.h
+++ b/lib/SCSI2SD/src/firmware/DaynaPort/sl003_core.h
@@ -84,17 +84,28 @@ typedef struct sl003 {
     /* What the last READ emitted -- the batch depth, for instrumentation. */
     uint16_t  records_sent;
 
-    /* DATA OUT landing area, at least SL003_PKT_MAX + 8 bytes, supplied
-     * by the caller (the firmware passes scsiDev.data rather than
-     * spending 1.5 KB of static RAM; the RP2040 targets have none to
-     * spare). CDB[3..4] is sixteen untrusted bits and fetch fills
-     * exactly the count we ask for, so every requested length is
-     * clamped to SL003_PKT_MAX. */
+    /* Data-phase scratch, at least SL003_PKT_MAX plus two record
+     * headers (one record and the closing one), supplied by the caller
+     * (the firmware passes scsiDev.data rather than spending 1.5 KB of
+     * static RAM; the RP2040 targets have none to spare).
+     *
+     * Two uses, never at once: the DATA OUT landing area, and the
+     * staging area for seamless emission. CDB[3..4] is sixteen
+     * untrusted bits and fetch fills exactly the count we ask for, so
+     * every requested length is clamped to SL003_PKT_MAX.
+     *
+     * wbuf_len caps a seamless batch: a whole batch is staged and sent
+     * as ONE transfer, never split, so give it the read allocation you
+     * are willing to serve (the firmware passes the full SCSI buffer).
+     * A batch that would outgrow it ends early instead, records kept
+     * whole, and the rest lead the next command. */
     uint8_t  *wbuf;
+    uint32_t  wbuf_len;
 } sl003_t;
 
 void     sl003_init(sl003_t *s, const uint8_t mac[6],
-                    struct scsiNetworkPacketQueue *ring, uint8_t *wbuf);
+                    struct scsiNetworkPacketQueue *ring,
+                    uint8_t *wbuf, uint32_t wbuf_len);
 
 /*
  * Inter-record pacing, default 75/300 us as observed from the real

--- a/lib/SCSI2SD/src/firmware/DaynaPort/sl003_core.h
+++ b/lib/SCSI2SD/src/firmware/DaynaPort/sl003_core.h
@@ -84,14 +84,17 @@ typedef struct sl003 {
     /* What the last READ emitted -- the batch depth, for instrumentation. */
     uint16_t  records_sent;
 
-    /* DATA OUT landing area. CDB[3..4] is sixteen untrusted bits and fetch
-     * fills exactly the count we ask for, so every requested length is
-     * clamped to this buffer. */
-    uint8_t   wbuf[SL003_PKT_MAX + 8];
+    /* DATA OUT landing area, at least SL003_PKT_MAX + 8 bytes, supplied
+     * by the caller (the firmware passes scsiDev.data rather than
+     * spending 1.5 KB of static RAM; the RP2040 targets have none to
+     * spare). CDB[3..4] is sixteen untrusted bits and fetch fills
+     * exactly the count we ask for, so every requested length is
+     * clamped to SL003_PKT_MAX. */
+    uint8_t  *wbuf;
 } sl003_t;
 
 void     sl003_init(sl003_t *s, const uint8_t mac[6],
-                    struct scsiNetworkPacketQueue *ring);
+                    struct scsiNetworkPacketQueue *ring, uint8_t *wbuf);
 
 /*
  * Inter-record pacing, default 75/300 us as observed from the real

--- a/lib/SCSI2SD/src/firmware/DaynaPort/sl003_core.h
+++ b/lib/SCSI2SD/src/firmware/DaynaPort/sl003_core.h
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 Ingo Paschke <ipaschke@lpclabs.de>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/* SL003 protocol core. No I/O of its own, no allocation.
+ *
+ * Structured like the ROM: a dispatch (0x0b5e) into one handler per
+ * opcode, data phases inline. The bus is injected as an sl003_io.
+ */
+#ifndef SL003_CORE_H
+#define SL003_CORE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "sl003_proto.h"
+#include "../network.h"   /* the shared receive ring */
+
+#define SL003_PKT_MAX       1520          /* frame incl FCS, even */
+#define SL003_MULTICAST_MAX   16
+
+/* Payload emission points straight into ring slots, so a slot must never be
+ * larger than the biggest record the core emits. */
+_Static_assert(NETWORK_PACKET_MAX_SIZE <= SL003_PKT_MAX,
+               "ring slot larger than the maximum record the core emits");
+
+typedef enum {
+    SL003_OK = 0,
+    SL003_CHECK_CONDITION = 1,   /* bad opcode, or the disabled gate */
+    SL003_CHECK_FIELD = 2        /* opcode fine, a CDB field is not */
+} sl003_result;
+
+/*
+ * The I/O the core drives. All calls are synchronous; a pointer passed to
+ * emit (possibly into a ring slot) is done with when emit returns.
+ *
+ *   emit   DATA IN. false = bus gone; the handler stops.
+ *   fetch  DATA OUT, exactly len bytes. false = bus gone or transfer
+ *          failed; the handler stops, the caller records which.
+ *   gap    inter-record pacing in microseconds; may be a no-op.
+ *   tx     a completed outbound frame, valid for the call's duration.
+ */
+typedef struct sl003_io {
+    bool (*emit)(void *ctx, const uint8_t *data, uint16_t len);
+    bool (*fetch)(void *ctx, uint8_t *buf, uint16_t len);
+    void (*gap)(void *ctx, uint16_t us);
+    void (*tx)(void *ctx, const uint8_t *frame, uint16_t len);
+    void *ctx;
+} sl003_io;
+
+typedef struct sl003 {
+    uint8_t   mac[6];
+    uint8_t   multicast[SL003_MULTICAST_MAX][6];
+    uint8_t   multicast_count;
+    bool      multicast_dirty;   /* a list arrived; the filter needs it */
+    uint8_t   mode;
+    bool      mode_set;
+    bool      enabled;
+
+    /* Not owned: filled by scsiNetworkEnqueue, also read by the Amiga
+     * personality. Single producer / single consumer: the producer owns
+     * writeIndex and never writes the slot at readIndex (full ring
+     * drops); we own readIndex and advance it only after emit() has
+     * returned for the payload pointing into the slot. */
+    struct scsiNetworkPacketQueue *rx;
+
+    uint32_t  ctr_missed_seen, ctr_crc, ctr_align, ctr_overrun;
+
+    /* configuration */
+    uint16_t  gap_header_us;     /* pacing, see sl003_set_gaps */
+    uint16_t  gap_record_us;
+
+    /* What the last READ emitted -- the batch depth, for instrumentation. */
+    uint16_t  records_sent;
+
+    /* DATA OUT landing area. CDB[3..4] is sixteen untrusted bits and fetch
+     * fills exactly the count we ask for, so every requested length is
+     * clamped to this buffer. */
+    uint8_t   wbuf[SL003_PKT_MAX + 8];
+} sl003_t;
+
+void     sl003_init(sl003_t *s, const uint8_t mac[6],
+                    struct scsiNetworkPacketQueue *ring);
+
+/*
+ * Inter-record pacing, default 75/300 us as observed from the real
+ * device. Required by hosts whose blind read is a software-timed loop
+ * (Mac Plus, SE/30): their blind mode fails at 0/0. Handshaked
+ * initiators may run 0.
+ */
+void     sl003_set_gaps(sl003_t *s, uint16_t header_us, uint16_t record_us);
+
+uint16_t sl003_rx_count(const sl003_t *s);
+/* Records emitted by the READ that just ran -- the batch depth. */
+uint16_t sl003_records_sent(const sl003_t *s);
+
+/*
+ * One SCSI command, start to finish: gate, dispatch, and every data phase,
+ * driven through io. The ROM's 0x0b5e dispatch, with the bus abstracted.
+ */
+sl003_result sl003_handle(sl003_t *s, const uint8_t cdb[6],
+                          const sl003_io *io);
+
+bool sl003_enabled(const sl003_t *s);
+bool sl003_mode_set(const sl003_t *s);
+
+/*
+ * Receiver error counters; 0x09 reports and clears them.
+ * sl003_count_missed accumulates a delta: hand each drop over exactly
+ * once, not as a running total. Only the missed counter has a producer;
+ * crc/align/overrun read as zero.
+ */
+void           sl003_count_missed(sl003_t *s, uint32_t n);
+void           sl003_count_crc(sl003_t *s);
+void           sl003_count_align(sl003_t *s);
+void           sl003_count_overrun(sl003_t *s);
+const uint8_t *sl003_mac(const sl003_t *s);
+
+/* True after ADD MULTICAST delivered a list; cleared by the read. Guards
+ * against re-programming the filter from a stale list when a command
+ * never reached DATA OUT. */
+bool           sl003_multicast_take(sl003_t *s);
+uint8_t        sl003_multicast_count(const sl003_t *s);
+const uint8_t *sl003_multicast_addr(const sl003_t *s, uint8_t i);
+
+#endif

--- a/lib/SCSI2SD/src/firmware/DaynaPort/sl003_proto.h
+++ b/lib/SCSI2SD/src/firmware/DaynaPort/sl003_proto.h
@@ -36,6 +36,13 @@
 
 /* CDB[5] selectors */
 #define SL003_READ_BLIND_BIT        0x40  /* clear = polled (0x0f3b)      */
+/* BlueSCSI extension, paired with SL003_INQ_BATCH_BOUNDED below: bound
+ * this blind batch to the allocation length. The ROM tests only bit 6
+ * here and ignores the rest of the control byte, so a real device
+ * treats the command as a plain blind read -- which is why a host must
+ * see the INQUIRY capability bit before relying on this one. Without
+ * the bit the batch streams unbounded, exactly as the ROM does. */
+#define SL003_READ_BOUNDED_BIT      0x20
 #define SL003_WRITE_STREAM_BIT      0x80  /* clear = one raw packet       */
 #define SL003_ENABLE_BIT            0x80  /* 0x0e: set = enable           */
 #define SL003_SETMODE_MODE_BIT      0x80  /* 0x0c: mode byte in CDB[4]    */
@@ -75,6 +82,19 @@
 /* INQUIRY byte 36 status bits (0x1500, 0x150e) */
 #define SL003_INQ_ENABLED           0x80
 #define SL003_INQ_MODE_SET          0x40
+
+/* BlueSCSI extension, not in the ROM: this emulation honors
+ * SL003_READ_BOUNDED_BIT on blind READs, bounding the batch to the
+ * allocation length. The real ROM builds byte 36 from the two bits above
+ * only (1.3 at 0x1448, 2.0 at 0x1500: XOR A, then OR 0x80 / OR 0x40), so
+ * this bit is never set by real hardware, and pre-SL003 BlueSCSI
+ * firmware answers a 36-byte INQUIRY with no byte 36 at all. Bit 0
+ * rather than the next free high bit on purpose: Dayna allocated this
+ * byte top-down, so the bottom is the position least likely to collide
+ * with any firmware revision that was never dumped. Hosts that need the
+ * bound (fixed-length initiators such as Atari SCSIDRV) probe this bit
+ * and fall back to polled reads without it. */
+#define SL003_INQ_BATCH_BOUNDED     0x01
 
 #define SL003_SENSE_ILLEGAL_REQUEST  5
 

--- a/lib/SCSI2SD/src/firmware/DaynaPort/sl003_proto.h
+++ b/lib/SCSI2SD/src/firmware/DaynaPort/sl003_proto.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Ingo Paschke <ipaschke@lpclabs.de>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/* SL003 SCSI/Link wire protocol constants.
+ *
+ * Values come from the disassembly of the Dayna SL003 v2.0 firmware; ROM
+ * addresses are cited. Suitable for host drivers too.
+ */
+#ifndef SL003_PROTO_H
+#define SL003_PROTO_H
+
+/* Opcodes. The ROM dispatches these from a table at 0x0b5e; anything else
+ * reaches thunk_illegal_default and is rejected. */
+#define SL003_CMD_TEST_UNIT_READY   0x00
+#define SL003_CMD_REQUEST_SENSE     0x03
+#define SL003_CMD_READ              0x08
+#define SL003_CMD_READ_STATS        0x09
+#define SL003_CMD_WRITE             0x0a
+#define SL003_CMD_SET_MODE          0x0c
+#define SL003_CMD_ADD_MULTICAST     0x0d
+#define SL003_CMD_ENABLE            0x0e
+#define SL003_CMD_INQUIRY           0x12
+
+/* CDB[5] selectors */
+#define SL003_READ_BLIND_BIT        0x40  /* clear = polled (0x0f3b)      */
+#define SL003_WRITE_STREAM_BIT      0x80  /* clear = one raw packet       */
+#define SL003_ENABLE_BIT            0x80  /* 0x0e: set = enable           */
+#define SL003_SETMODE_MODE_BIT      0x80  /* 0x0c: mode byte in CDB[4]    */
+#define SL003_SETMODE_ADDR_BIT      0x40  /* 0x0c: 6-byte MAC in DATA OUT */
+
+/* Record: [len hi][len lo][0][0][0][flags]. len includes the 4-byte FCS. */
+#define SL003_RECORD_HDR_LEN        6
+#define SL003_FRAME_MAX             1518
+#define SL003_READ_ALLOC            1524  /* header + max frame           */
+
+/* Flags byte (header byte 5) */
+#define SL003_FLAG_MORE             0x10  /* more packets queued (0x0ca6) */
+#define SL003_FLAG_RUNT             0x80  /* only once a mode is set      */
+
+/* Blind batches stop here and emit a zero-length terminator (0x0d5c,
+ * 0x0c1c). v1.3 had no cap at all. Overridable so tests can reach the cap
+ * without queueing 200 packets. */
+#ifndef SL003_BLIND_RECORD_CAP
+#define SL003_BLIND_RECORD_CAP      200
+#endif
+
+/* Inter-record gaps measured on a bus analyser. The ROM contains no
+ * programmed delays; these are emergent Z180/DMA turnaround, and a
+ * software-timed blind host depends on them. */
+/* The largest record on the wire: a full frame with its FCS, plus the
+ * six-byte header. Not SL003_PKT_MAX, which sizes a ring slot. */
+#define SL003_MAX_RECORD            (1518 + SL003_RECORD_HDR_LEN)
+
+#define SL003_GAP_AFTER_HEADER_US    75
+#define SL003_GAP_AFTER_RECORD_US   300
+
+/* Replies */
+#define SL003_INQUIRY_LEN           37    /* clamp at 0x151c              */
+#define SL003_STATS_LEN             22    /* MAC + four 32-bit counters   */
+#define SL003_SENSE_LEN              9
+
+/* INQUIRY byte 36 status bits (0x1500, 0x150e) */
+#define SL003_INQ_ENABLED           0x80
+#define SL003_INQ_MODE_SET          0x40
+
+#define SL003_SENSE_ILLEGAL_REQUEST  5
+
+#endif

--- a/lib/SCSI2SD/src/firmware/DaynaPort/sl003_proto.h
+++ b/lib/SCSI2SD/src/firmware/DaynaPort/sl003_proto.h
@@ -95,6 +95,23 @@
  * bound (fixed-length initiators such as Atari SCSIDRV) probe this bit
  * and fall back to polled reads without it. */
 #define SL003_INQ_BATCH_BOUNDED     0x01
+/* Seamless emission honored. Advertised separately from the bounded
+ * bit so a host never has to infer one capability from the other: a
+ * device could honor the bound yet ignore the seamless request, and a
+ * SCSI Manager 4.3 host that assumed otherwise would corrupt (see the
+ * seamless bit below). Gate the CDB bit on this one. */
+#define SL003_INQ_SEAMLESS          0x02
+
+/* READ CDB[5] bit 0x10: emit the whole answer as one transfer, with no
+ * pause inside it and none between records either. Requested by
+ * hardware-handshaked hosts whose SIM fabricates a word when the
+ * device pauses REQ mid data phase
+ * (Quadra-era SCSI Manager 4.3, measured on an LC475). Without the
+ * bit the classic two-emit timing with the ROM's header and record
+ * gaps is preserved for software-timed hosts (Plus, SE/30). Real
+ * ROMs ignore unknown CDB[5] bits, same precedent as the bounded
+ * bit. */
+#define SL003_READ_SEAMLESS_BIT       0x10
 
 #define SL003_SENSE_ILLEGAL_REQUEST  5
 

--- a/lib/SCSI2SD/src/firmware/inquiry.c
+++ b/lib/SCSI2SD/src/firmware/inquiry.c
@@ -24,6 +24,9 @@
 #include "scsi.h"
 #include "config.h"
 #include "inquiry.h"
+#ifdef BLUESCSI_NETWORK
+#include "network.h"
+#endif
 #include "BlueSCSI_config.h"
 
 #include <string.h>
@@ -302,8 +305,22 @@ uint32_t s2s_getStandardInquiry(
 			size += sizeof(LaserWriterVendor);
 		}
 	}
+	/* The DaynaPORT answers 37 bytes: byte 36 is live status, 0x80 =
+	 * enabled, 0x40 = mode set (ROM 0x1500, 0x150e). Appended here
+	 * because scsi.c answers INQUIRY before any personality runs. */
+	else if (cfg->deviceType == S2S_CFG_NETWORK) {
+#ifdef BLUESCSI_NETWORK
+		if (size < maxlen)
+		{
+			out[size++] = scsiNetworkInquiryStatus();
+			// keep the additional-length byte in step, for two-step
+			// INQUIRY (read 5, re-issue with 4 + 1 + out[4])
+			out[4] = (uint8_t)(size - 5);
+		}
+#endif
+	}
 	// Iomega already has a vendor inquiry
-	else if(cfg->deviceType != S2S_CFG_NETWORK && cfg->deviceType != S2S_CFG_ZIP100) {
+	else if(cfg->deviceType != S2S_CFG_ZIP100) {
 		memcpy(&out[size], INQUIRY_NAME, sizeof(INQUIRY_NAME) - 1);
 		size += sizeof(INQUIRY_NAME) - 1;
 		out[size++] = TOOLBOX_API;

--- a/lib/SCSI2SD/src/firmware/network.c
+++ b/lib/SCSI2SD/src/firmware/network.c
@@ -22,9 +22,8 @@
 #include "config.h"
 #include "network.h"
 
-extern int platform_network_send(uint8_t *buf, size_t len);
-
 bool scsiNetworkEnabled = false;
+uint32_t scsiNetworkMissed = 0;   /* frames dropped on a full ring */
 struct scsiNetworkPacketQueue scsiNetworkInboundQueue;
 
 struct __attribute__((packed)) wifi_network_entry wifi_network_list[WIFI_NETWORK_LIST_ENTRY_COUNT] = { 0 };
@@ -211,271 +210,37 @@ void scsiNetworkWifiJoin(uint32_t size)
 	scsiDev.phase = STATUS;
 }
 
-int scsiNetworkCommand()
+/*
+ * WiFi configuration commands. A BlueSCSI extension on an opcode no emulated
+ * device ever used, so it is shared platform surface rather than part of any
+ * one personality.
+ */
+int scsiNetworkWifiCommand(void)
 {
-	int parityError, done, idx, total;
-	long len;
 	uint32_t size = (scsiDev.cdb[3] << 8) + scsiDev.cdb[4];
-	uint8_t command = scsiDev.cdb[0];
 
-	DBGMSG_F("------ in scsiNetworkCommand with command 0x%02x (size %d)", command, size);
+	DBGMSG_F("------ wi-fi command 0x%02x (size %d)", scsiDev.cdb[1], size);
 
-	switch (command) {
-	case 0x08:
-	{
-		// read(6)
-		// CDB[5] bit 6 indicates transfer mode from the host driver:
-		//   0x80 (bit 6 clear) = polled mode (old SCSI Manager, VM present) -> single packet
-		//   0xC0 (bit 6 set)   = blind mode (new SCSI Manager, no VM) -> multi-packet OK
-		// When bit 6 is clear, we send only one packet per READ(6) to minimize SCSI bus
-		// hold time, allowing the VM pager to access the bus between transactions.
-		int multiPacket = (scsiDev.cdb[5] & 0x40) != 0;
-
-		if (unlikely(size == 1))
-		{
-			scsiDev.status = CHECK_CONDITION;
-			scsiDev.phase = STATUS;
-			break;
-		}
-
-		// if we have nothing to send, just return early
-		if (scsiNetworkInboundQueue.readIndex == scsiNetworkInboundQueue.writeIndex)
-		{
-			scsiDev.data[0] = 0;
-			scsiDev.data[1] = 0;
-			scsiDev.data[2] = 0;
-			scsiDev.data[3] = 0;
-			scsiDev.data[4] = 0;
-			scsiDev.data[5] = 0;
-			scsiEnterPhase(DATA_IN);
-			scsiWrite(scsiDev.data, 6);
-			while (!scsiIsWriteFinished(NULL))
-			{
-				platform_poll();
-			}
-			scsiFinishWrite();
-			scsiDev.status = GOOD;
-			scsiDev.phase = STATUS;
-			break;
-		}
-
-		scsiEnterPhase(DATA_IN);
-
-		for (done = 0, total = 0; !done; )
-		{
-			idx = scsiNetworkInboundQueue.readIndex;
-			len = scsiNetworkInboundQueue.sizes[idx];
-			total += len + 6;  // packet data + 6-byte header
-
-			if (scsiNetworkInboundQueue.readIndex == NETWORK_PACKET_QUEUE_SIZE - 1)
-			{
-				scsiNetworkInboundQueue.readIndex = 0;
-			}
-			else
-			{
-				scsiNetworkInboundQueue.readIndex++;
-			}
-
-			done = (scsiNetworkInboundQueue.readIndex == scsiNetworkInboundQueue.writeIndex);
-
-			// In polled mode (bit 6 clear), only send one packet per READ(6)
-			// to avoid holding the SCSI bus while the VM pager needs it.
-			if (!done && !multiPacket)
-			{
-				done = 1;
-			}
-
-			// Don't exceed the transfer size requested by the host
-			if (!done && total + DAYNAPORT_SCSI_PACKET_MAX + 6 > size)
-			{
-				done = 1;
-			}
-
-			// Don't tie up the SCSI bus too long even in multi-packet mode
-			if (!done && total >= (DAYNAPORT_SCSI_PACKET_MAX + 6) * 2)
-			{
-				done = 1;
-			}
-
-			scsiDev.data[0] = (len >> 8) & 0xff;
-			scsiDev.data[1] = len & 0xff;
-			scsiDev.data[2] = 0;
-			scsiDev.data[3] = 0;
-			scsiDev.data[4] = 0;
-			scsiDev.data[5] = (done ? 0 : 0x10);
-
-			scsiWrite(scsiDev.data, 6);
-			while (!scsiIsWriteFinished(NULL))
-			{
-				platform_poll();
-			}
-			scsiFinishWrite();
-
-			// DaynaPort Mac driver needs a short delay after reading size and flags.
-			// Timing matches real DaynaPORT SCSI/Link-3 behavior observed on a SCSI bus analyzer.
-			sleep_us(75);
-
-			scsiWrite(scsiNetworkInboundQueue.packets[idx], len);
-			while (!scsiIsWriteFinished(NULL))
-			{
-				platform_poll();
-			}
-			scsiFinishWrite();
-
-			if (!done)
-			{
-				// DaynaPort Mac driver needs a delay between packets.
-				// Timing matches real DaynaPORT SCSI/Link-3 behavior observed on a SCSI bus analyzer.
-				sleep_us(300);
-			}
-		}
-
-		scsiDev.status = GOOD;
-		scsiDev.phase = STATUS;
+	switch (scsiDev.cdb[1]) {
+	case SCSI_NETWORK_WIFI_CMD_SCAN:
+		scsiNetworkWifiScan();
+		break;
+	case SCSI_NETWORK_WIFI_CMD_COMPLETE:
+		scsiNetworkWifiComplete();
+		break;
+	case SCSI_NETWORK_WIFI_CMD_SCAN_RESULTS:
+		scsiNetworkWifiScanResults(size);
+		break;
+	case SCSI_NETWORK_WIFI_CMD_INFO:
+		scsiNetworkWifiInfo();
+		break;
+	case SCSI_NETWORK_WIFI_CMD_JOIN:
+		scsiNetworkWifiJoin(size);
 		break;
 	}
 
-	case 0x09:
-		// read mac address and stats
-		memcpy(scsiDev.data, scsiDev.boardCfg.wifiMACAddress, sizeof(scsiDev.boardCfg.wifiMACAddress));
-		memset(scsiDev.data + sizeof(scsiDev.boardCfg.wifiMACAddress), 0,
-			sizeof(scsiDev.data) - sizeof(scsiDev.boardCfg.wifiMACAddress));
-
-		// three 32-bit counters expected to follow, just return zero for all
-		scsiDev.dataLen = 18;
-		scsiDev.phase = DATA_IN;
-		break;
-
-	case 0x0a:
-		// write(6)
-		scsiEnterPhase(DATA_OUT);
-
-		for (;;)
-		{
-			if (scsiDev.cdb[5] == 0x0)
-			{
-				// no preamble, single packet
-				len = size;
-				DBGMSG_F("no-preamble write, size %ld (cdb %02x %02x %02x %02x %02x %02x)", len,
-					scsiDev.cdb[0], scsiDev.cdb[1], scsiDev.cdb[2], scsiDev.cdb[3], scsiDev.cdb[4], scsiDev.cdb[5]);
-			}
-			else
-			{
-				// read size of this packet
-				scsiRead(scsiDev.data, 4, &parityError);
-				if (parityError)
-				{
-					DBGMSG_F("%s: read of size from host had parity error %d", __func__, parityError);
-				}
-
-				len = (scsiDev.data[0] << 8) + scsiDev.data[1];
-				if (len == 0)
-				{
-					// final packet was read in previous iteration
-					break;
-				}
-			}
-
-			if (len > NETWORK_PACKET_MAX_SIZE)
-			{
-				DBGMSG_F("%s: attempt to write(6) packet of size %zu", __func__, len);
-				len = NETWORK_PACKET_MAX_SIZE;
-			}
-
-			scsiRead(scsiDev.data, len, &parityError);
-			if (parityError)
-			{
-				DBGMSG_F("%s: read from host of size %zu had parity error %d", __func__, size, parityError);
-			}
-
-			platform_network_send(scsiDev.data, len);      
-
-			if (scsiDev.cdb[5] == 0x0)
-			{
-				// single-packet mode
-				break;
-			}
-		}
-
-		scsiDev.status = GOOD;
-		scsiDev.phase = STATUS;
-		break;
-
-	case 0x0c:
-		// set interface mode (ignored)
-		//broadcasts = (scsiDev.cdb[4] == 0x04);
-		break;
-
-	case 0x0d:
-		// add multicast addr to network filter
-		memset(scsiDev.data, 0, sizeof(scsiDev.data));
-		scsiEnterPhase(DATA_OUT);
-		parityError = 0;
-		scsiRead(scsiDev.data, size, &parityError);
-
-		DBGMSG_F("%s: adding multicast address %02x:%02x:%02x:%02x:%02x:%02x", __func__,
-			  scsiDev.data[0], scsiDev.data[1], scsiDev.data[2], scsiDev.data[3], scsiDev.data[4], scsiDev.data[5]);
-
-
-		platform_network_add_multicast_address(scsiDev.data);
-
-		scsiDev.status = GOOD;
-		scsiDev.phase = STATUS;
-		break;
-
-	case 0x0e:
-		// toggle interface
-		if (scsiDev.cdb[5] & 0x80)
-		{
-			DBGMSG_F("%s: enable interface", __func__);
-			scsiNetworkEnabled = true;
-			memset(&scsiNetworkInboundQueue, 0, sizeof(scsiNetworkInboundQueue));
-		}
-		else
-		{
-			DBGMSG_F("%s: disable interface", __func__);
-			scsiNetworkEnabled = false;
-		}
-		break;
-
-	case 0x1a:
-		// mode sense (ignored)
-		break;
-
-	case 0x40:
-		// set MAC (ignored)
-		scsiDev.dataLen = 6;
-		scsiDev.phase = DATA_OUT;
-		break;
-
-	case 0x80:
-		// set mode (ignored)
-		break;
-
-	// custom wifi commands all using the same opcode, with a sub-command in cdb[2]
-	case SCSI_NETWORK_WIFI_CMD:
-		DBGMSG_F("------ in scsiNetworkCommand with wi-fi command 0x%02x (size %d)", scsiDev.cdb[2], size);
-
-		switch (scsiDev.cdb[1]) {
-		case SCSI_NETWORK_WIFI_CMD_SCAN:
-			scsiNetworkWifiScan();
-			break;
-		case SCSI_NETWORK_WIFI_CMD_COMPLETE:
-			scsiNetworkWifiComplete();
-			break;
-		case SCSI_NETWORK_WIFI_CMD_SCAN_RESULTS:
-			scsiNetworkWifiScanResults(size);
-			break;
-		case SCSI_NETWORK_WIFI_CMD_INFO:
-			scsiNetworkWifiInfo();
-			break;
-		case SCSI_NETWORK_WIFI_CMD_JOIN:
-			scsiNetworkWifiJoin(size);
-			break;
-		}
-		break;
-	}
-
+	/* No status write here: each subcommand owns its phase (queries leave
+	 * DATA_IN for scsi.c; scan-results errors set CHECK_CONDITION). */
 	return 1;
 }
 
@@ -487,6 +252,20 @@ int scsiNetworkEnqueue(const uint8_t *buf, size_t len)
 	if (len + 4 > sizeof(scsiNetworkInboundQueue.packets[0]))
 	{
 		DBGMSG_F("%s: dropping incoming network packet, too large (%zu > %zu)", __func__, len, sizeof(scsiNetworkInboundQueue.packets[0]));
+		return 0;
+	}
+
+	uint8_t nextWriteIndex = (scsiNetworkInboundQueue.writeIndex == NETWORK_PACKET_QUEUE_SIZE - 1)
+		? 0 : scsiNetworkInboundQueue.writeIndex + 1;
+
+	/* Full ring: drop before touching the slot. Advancing writeIndex onto
+	 * readIndex would make a full queue look empty, and the reader may
+	 * still hold a pointer into the slot. The drop feeds the
+	 * missed-packet counter, as on the real hardware. */
+	if (nextWriteIndex == scsiNetworkInboundQueue.readIndex)
+	{
+		DBGMSG_F("%s: ring full, dropping incoming packet", __func__);
+		scsiNetworkMissed++;
 		return 0;
 	}
 
@@ -506,16 +285,7 @@ int scsiNetworkEnqueue(const uint8_t *buf, size_t len)
 
 	scsiNetworkInboundQueue.sizes[scsiNetworkInboundQueue.writeIndex] = len + 4;
 
-	if (scsiNetworkInboundQueue.writeIndex == NETWORK_PACKET_QUEUE_SIZE - 1)
-		scsiNetworkInboundQueue.writeIndex = 0;
-	else
-		scsiNetworkInboundQueue.writeIndex++;
-
-	if (scsiNetworkInboundQueue.writeIndex == scsiNetworkInboundQueue.readIndex)
-	{
-		DBGMSG_F("%s: dropping packets in ring, write index caught up to read index", __func__);
-	}
-
+	scsiNetworkInboundQueue.writeIndex = nextWriteIndex;
 	return 1;
 }
 

--- a/lib/SCSI2SD/src/firmware/network.c
+++ b/lib/SCSI2SD/src/firmware/network.c
@@ -21,6 +21,7 @@
 #include "scsiPhy.h"
 #include "config.h"
 #include "network.h"
+#include "hardware/sync.h"
 
 bool scsiNetworkEnabled = false;
 uint32_t scsiNetworkMissed = 0;   /* frames dropped on a full ring */
@@ -285,6 +286,9 @@ int scsiNetworkEnqueue(const uint8_t *buf, size_t len)
 
 	scsiNetworkInboundQueue.sizes[scsiNetworkInboundQueue.writeIndex] = len + 4;
 
+	/* Publish last: this runs from an IRQ while a SCSI command reads the
+	 * ring, so packet and size must be visible before the index. */
+	__dmb();
 	scsiNetworkInboundQueue.writeIndex = nextWriteIndex;
 	return 1;
 }

--- a/lib/SCSI2SD/src/firmware/network.h
+++ b/lib/SCSI2SD/src/firmware/network.h
@@ -67,7 +67,17 @@ struct __attribute__((packed)) wifi_join_request {
 #define SCSI_NETWORK_WIFI_CMD_INFO			0x04
 #define SCSI_NETWORK_WIFI_CMD_JOIN			0x05
 
-int scsiNetworkCommand(void);
+/* Shared receive ring: the radio fills it, either network personality
+ * reads it. */
+extern bool scsiNetworkEnabled;
+extern struct scsiNetworkPacketQueue scsiNetworkInboundQueue;
+
+int scsiNetworkCommand(void);        /* DaynaPort/DaynaPort.c */
+int scsiNetworkWifiCommand(void);    /* shared WiFi configuration */
+extern uint32_t scsiNetworkMissed;
+
+/* INQUIRY byte 36, delivered by inquiry.c's generic path. */
+uint8_t scsiNetworkInquiryStatus(void);
 int scsiNetworkEnqueue(const uint8_t *buf, size_t len);
 
 // Shared WiFi subcommand handlers (used by both DaynaPort and AmigaWIFI)

--- a/src/BlueSCSI_config.h
+++ b/src/BlueSCSI_config.h
@@ -103,7 +103,17 @@
 #define DRIVEINFO_OPTICAL   {"BLUESCSI", "CDROM",     PLATFORM_REVISION, ""}
 #define DRIVEINFO_FLOPPY    {"BLUESCSI", "FLOPPY",    PLATFORM_REVISION, ""}
 #define DRIVEINFO_MAGOPT    {"BLUESCSI", "MO_DRIVE",  PLATFORM_REVISION, ""}
-#define DRIVEINFO_NETWORK   {"Dayna",    "SCSI/Link",       "2.0f", ""}
+/*
+ * Revision "2.4f", not the real device's "2.0f": Apple's .ENET0 driver
+ * decides whether to mask interrupts for the whole of every SCSI poll by
+ * comparing INQUIRY byte 34 -- the THIRD character of this string --
+ * against '4' ("firmware 1.4 or later survives interrupts"). The check
+ * only looks at the minor digit, so the genuine "2.0f" reads as ancient
+ * and every poll runs at IPL 6: ticks are lost, TickCount-based rates
+ * read up to 2x high, and the machine is deaf during transfers. Byte 34
+ * = '4' keeps interrupts on, the path Dayna shipped for 1.4a.
+ */
+#define DRIVEINFO_NETWORK   {"Dayna",    "SCSI/Link",       "2.4f", ""}
 #define DRIVEINFO_TAPE      {"BLUESCSI", "TAPE",      PLATFORM_REVISION, ""}
 #define DRIVEINFO_AMIGAWIFI {"AmigaNET", "SCSI/Link", "1.0f", ""}
 #define DRIVEINFO_PRINTER   {"APPLE",    "PERSONAL LASER", "1.00", ""}
@@ -126,7 +136,7 @@
 #define APPLE_DRIVEINFO_OPTICAL   {"BlueSCSI", "CD-ROM CDU-55S",   "1.9a", ""}
 #define APPLE_DRIVEINFO_FLOPPY    {"IOMEGA",   "Io20S         *F", "PP33", ""}
 #define APPLE_DRIVEINFO_MAGOPT    {"MOST",     "RMD-5200",          PLATFORM_REVISION, "1.0"}
-#define APPLE_DRIVEINFO_NETWORK   {"Dayna",    "SCSI/Link",       "2.0f", ""}
+#define APPLE_DRIVEINFO_NETWORK   {"Dayna",    "SCSI/Link",       "2.4f", ""}
 #define APPLE_DRIVEINFO_TAPE      {"BlueSCSI", "APPLE_TAPE",        PLATFORM_REVISION, ""}
 #define APPLE_DRIVEINFO_PRINTER   {"APPLE",    "PERSONAL LASER",    "1.00", ""}
 


### PR DESCRIPTION
Follow-up to #399, and intended to supersede it. #399 patched the
existing handler toward what the real SCSI/Link does, based on
disassembling Dayna's Mac driver. Since then I've disassembled the
device itself: the SL003 v2.0 Z180 ROM (and 1.3 for comparison), plus
Apple's `.ENET0` 1.2.2f0 and Dayna's last 1.2.5f1. With the actual
firmware on the table, patching the old handler further made less sense
than rewriting the emulation against the ROM, so that's what this is.

The protocol logic now lives in a standalone core
(`lib/SCSI2SD/src/firmware/DaynaPort/`) transcribed from the ROM
disassembly, with ROM addresses cited in comments. The core has no I/O
of its own; a small personality file connects it to the bus and the
radio. `network.c` keeps the shared queue/wifi plumbing, and AmigaWIFI
is untouched next to it.

What it does that #399's version didn't:

- Polled READ(6) exactly as the ROM: one record per command, live
  more-pending flag, and the stateless peek/resume through CDB[1..2]
  the Mac driver uses under VM.
- Blind READ(6) as a record stream whose receive ring refills
  mid-transaction: the radio runs from a low-priority IRQ
  (threadsafe-background cyw43 arch, scoped to Pico_2_DaynaPORT; other
  targets stay on the poll arch). A batch is no longer capped at
  whatever was queued when it started.
- A capability contract for fixed-length initiators: INQUIRY byte 36
  bit 0 declares that CDB[5] bit 0x20 on a blind READ bounds the batch
  to the allocation length. Atari SCSIDRV programs a fixed transfer
  length with no residual reporting, so an unbounded stream is fatal
  there. Both dumped ROMs build byte 36 from the enabled/mode bits
  only, so real hardware never sets bit 0, and without the request bit
  every read streams exactly like the ROM. The paired FreeMiNT driver
  (0.90, on my freemint fork) probes the bit and falls back to polled
  single-record i/o on real hardware, PiSCSI, or older firmware.
- READ STATS returns the real device's 22 bytes with a working
  read-and-clear missed counter; ADD MULTICAST programs the radio
  filter (EtherTalk/mDNS work); SET MAC returns CHECK CONDITION instead
  of silently doing nothing (the radio can't change its receive
  address).
- INQUIRY reports revision 2.4f: the Mac driver masks interrupts around
  every SCSI poll unless byte 34 is '4' or higher, and it only reads
  the minor digit, so genuine "2.0f" hardware ran masked on every
  driver Dayna ever shipped. 2.4f takes the unmasked path Dayna built
  for firmware 1.4a.
- Inter-record pacing (75/300 us, matching the real device's timing)
  configurable via bluescsi.ini, plus a WiFiPowerSave option, default
  off.

The ring-full fix and the 48-slot ring from #399 are carried over; the
multi-record read semantics are now the ROM's rather than an
approximation.

Tested in both directions, wire-measured server-side: Atari Falcon
(FreeMiNT), Mac LC475 and SE/30 (7.5.5/Open Transport), Mac Plus
(7.0.1/MacTCP). The protocol core is additionally covered by ~320
host-side unit checks including a loopback test against the FreeMiNT
driver's parser; the test suite lives on a separate branch to keep this
PR to firmware, happy to submit it as a follow-up if wanted.
