### PR TITLE
Wi-Fi Security

### DIFF
--- a/lib/BlueSCSI_platform_RP2MCU/BlueSCSI_platform_network.cpp
+++ b/lib/BlueSCSI_platform_RP2MCU/BlueSCSI_platform_network.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023 joshua stein <jcs@jcs.org>
+ * Copyright (c) 2026 Eric Helgeson <eric@bluescsi.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -18,6 +19,7 @@
 #include "BlueSCSI_platform_network.h"
 #include "BlueSCSI_log.h"
 #include "BlueSCSI_config.h"
+#include "BlueSCSI_settings.h"
 #include <scsi.h>
 #include <network.h>
 
@@ -51,6 +53,35 @@ static bool network_iface_present = false;
 static uint32_t wifi_reconnect_time = 0;
 static uint32_t wifi_reconnect_interval = WIFI_RECONNECT_INTERVAL;
 static int wifi_reconnect_attempts = 0;
+
+// How long to wait for an association to finish before reporting it stalled.
+#define WIFI_JOIN_STALL_TIMEOUT 30000
+
+// Start of the most recent join attempt, or 0 once the link is up.
+static uint32_t wifi_join_time = 0;
+static bool wifi_join_stall_reported = false;
+
+static const char *wifi_security_name(uint8_t security)
+{
+	switch (security)
+	{
+		case WIFI_SECURITY_WPA2_AES:  return "WPA2 AES PSK";
+		case WIFI_SECURITY_WPA3:      return "WPA3 SAE";
+		case WIFI_SECURITY_WPA3_WPA2: return "WPA3/WPA2 SAE";
+		default:                      return "WPA/WPA2 PSK";
+	}
+}
+
+static uint32_t wifi_security_auth(uint8_t security)
+{
+	switch (security)
+	{
+		case WIFI_SECURITY_WPA2_AES:  return CYW43_AUTH_WPA2_AES_PSK;
+		case WIFI_SECURITY_WPA3:      return CYW43_AUTH_WPA3_SAE_AES_PSK;
+		case WIFI_SECURITY_WPA3_WPA2: return CYW43_AUTH_WPA3_WPA2_AES_PSK;
+		default:                      return CYW43_AUTH_WPA2_MIXED_PSK;
+	}
+}
 
 bool platform_network_supported()
 {
@@ -157,13 +188,18 @@ bool platform_network_wifi_join(char *ssid, char *password, bool reconnect)
 	}
 	else
 	{
+		uint8_t security = scsiDev.boardCfg.wifiSecurity;
+
 		if (!reconnect)
-			logmsg("Connecting to Wi-Fi SSID \"", ssid, "\" with WPA/WPA2 PSK");
-		ret = cyw43_arch_wifi_connect_async(ssid, password, CYW43_AUTH_WPA2_MIXED_PSK);
+			logmsg("Connecting to Wi-Fi SSID \"", ssid, "\" with ", wifi_security_name(security));
+		ret = cyw43_arch_wifi_connect_async(ssid, password, wifi_security_auth(security));
 	}
 
 	if (ret == 0)
 	{
+		wifi_join_time = platform_millis();
+		wifi_join_stall_reported = false;
+
 		if (!reconnect)
 		{
 			// Short single blink at start of connection sequence
@@ -196,7 +232,8 @@ void platform_network_poll()
 				logmsg("Wi-Fi connected to ", ssid, " but was not assigned an IP");
 				break;
 			case CYW43_LINK_BADAUTH:
-				logmsg("Wi-Fi authentication failure connecting to \"", ssid, "\", please check the setting \"WiFiPassword\" in ", CONFIGFILE);
+				logmsg("Wi-Fi authentication failure connecting to \"", ssid, "\", please check the settings \"WiFiPassword\" and \"WiFiSecurity\" (currently ",
+					wifi_security_name(scsiDev.boardCfg.wifiSecurity), ") in ", CONFIGFILE);
 				break;
 			case CYW43_LINK_NONET:
 				logmsg("Wi-Fi SSID ", ssid, " not found, possible out of range or down");
@@ -206,6 +243,17 @@ void platform_network_poll()
 				break;
 		}
 		wifi_reconnect_time = platform_millis();
+	}
+
+	// An association that never completes sits at CYW43_LINK_JOIN forever
+	if (!wifi_join_stall_reported
+		&& wifi_join_time != 0
+		&& status == CYW43_LINK_JOIN
+		&& (uint32_t)(platform_millis() - wifi_join_time) > WIFI_JOIN_STALL_TIMEOUT)
+	{
+		wifi_join_stall_reported = true;
+		logmsg("Wi-Fi association to \"", ssid, "\" has not completed after 30 seconds, if it does not connect check that \"WiFiSecurity\" (currently ",
+			wifi_security_name(scsiDev.boardCfg.wifiSecurity), ") in ", CONFIGFILE, " matches the access point");
 	}
 
 	// Reset reconnect state when link comes back up
@@ -424,6 +472,10 @@ void cyw43_cb_tcpip_set_link_down(cyw43_t *self, int itf)
 void cyw43_cb_tcpip_set_link_up(cyw43_t *self, int itf)
 {
 	char *ssid = platform_network_wifi_ssid();
+
+	// The link is genuinely up, so stop watching for a stalled association.
+	wifi_join_time = 0;
+	wifi_join_stall_reported = false;
 
 	if (ssid)
 	{

--- a/lib/BlueSCSI_platform_RP2MCU/rp2040-template.ld
+++ b/lib/BlueSCSI_platform_RP2MCU/rp2040-template.ld
@@ -175,6 +175,12 @@ SECTIONS
         *(.text*setNameFromImage*)
         *(.text*getBlockSize*)
 
+        /* Wi-Fi association, only used during init and reconnect. Keeps the
+         * packet path (platform_network_send/receive) in RAM. */
+        *(.text*platform_network_wifi_join*)
+        *(.text*wifi_security_name*)
+        *(.text*wifi_security_auth*)
+
         /* SCSI commands that don't require high performance */
         *(.text*scsiToolboxCommand*)
         *(.text*scsi*Diagnostic*)

--- a/lib/SCSI2SD/include/scsi2sd.h
+++ b/lib/SCSI2SD/include/scsi2sd.h
@@ -1,5 +1,6 @@
 //	Copyright (C) 2014 Michael McMaster <michael@codesrc.com>
 //	Copyright (c) 2023 joshua stein <jcs@jcs.org>
+//	Copyright (c) 2026 Eric Helgeson <eric@bluescsi.com>
 //
 //	This file is part of SCSI2SD.
 //
@@ -167,7 +168,9 @@ typedef struct __attribute__((packed))
 
 	uint8_t busWidth; // Wide bus support, 0: 8-bit, 1: 16-bit, 2: 32-bit
 
-	uint8_t reserved[17]; // Pad out to 128 bytes
+	uint8_t wifiSecurity; // bluescsi_wifi_security_t, 0: WPA/WPA2 mixed PSK
+
+	uint8_t reserved[16]; // Pad out to 128 bytes
 } S2S_BoardCfg;
 
 typedef enum

--- a/lib/SCSI2SD/src/firmware/AmigaWIFI/AmigaWIFI.c
+++ b/lib/SCSI2SD/src/firmware/AmigaWIFI/AmigaWIFI.c
@@ -307,7 +307,7 @@ int amigaWifiCommand()
 		break;
 
 
-	// custom wifi commands all using the same opcode, with a sub-command in cdb[2] - same as the standard daynaport ones
+	// custom wifi commands all using the same opcode, with a sub-command in cdb[1] - same as the standard daynaport ones
 	case SCSI_CMD_WIFI: {
 		size = scsiDev.cdb[4] + (scsiDev.cdb[3] << 8);
 

--- a/lib/SCSI2SD/src/firmware/network.c
+++ b/lib/SCSI2SD/src/firmware/network.c
@@ -452,9 +452,9 @@ int scsiNetworkCommand()
 		// set mode (ignored)
 		break;
 
-	// custom wifi commands all using the same opcode, with a sub-command in cdb[2]
+	// custom wifi commands all using the same opcode, with a sub-command in cdb[1]
 	case SCSI_NETWORK_WIFI_CMD:
-		DBGMSG_F("------ in scsiNetworkCommand with wi-fi command 0x%02x (size %d)", scsiDev.cdb[2], size);
+		DBGMSG_F("------ in scsiNetworkCommand with wi-fi command 0x%02x (size %d)", scsiDev.cdb[1], size);
 
 		switch (scsiDev.cdb[1]) {
 		case SCSI_NETWORK_WIFI_CMD_SCAN:

--- a/src/BlueSCSI_disk.cpp
+++ b/src/BlueSCSI_disk.cpp
@@ -1,7 +1,7 @@
 /**
  * SCSI2SD V6 - Copyright (C) 2013 Michael McMaster <michael@codesrc.com>
  * Portions Copyright (C) 2014 Doug Brown <doug@downtowndougbrown.com>
- * Copyright (C) 2023 Eric Helgeson
+ * Copyright (c) 2023-2026 Eric Helgeson <eric@bluescsi.com>
  * ZuluSCSI™ - Copyright (c) 2022-2025 Rabbit Hole Computing™
  *
  * This file is licensed under the GPL version 3 or any later version. 
@@ -1701,6 +1701,14 @@ void s2s_configInit(S2S_BoardCfg* config)
     {
         memcpy(config->wifiPassword, tmp, sizeof(config->wifiPassword));
         logmsg("-- WiFiPassword = [set]");
+    }
+
+    memset(tmp, 0, sizeof(tmp));
+    ini_gets("SCSI", "WiFiSecurity", "", tmp, sizeof(tmp), CONFIGFILE);
+    if (tmp[0])
+    {
+        config->wifiSecurity = g_scsi_settings.stringToWifiSecurity(tmp);
+        logmsg("-- WiFiSecurity = ", tmp);
     }
 
 }

--- a/src/BlueSCSI_settings.cpp
+++ b/src/BlueSCSI_settings.cpp
@@ -2,7 +2,7 @@
  * This file is originally part of ZuluSCSI adopted for BlueSCSI
  *
  * ZuluSCSI™ - Copyright (c) 2023-2025 Rabbit Hole Computing™
- * Copyright (c) 2023-2025 Eric Helgeson
+ * Copyright (c) 2023-2026 Eric Helgeson <eric@bluescsi.com>
  * 
  * This file is licensed under the GPL version 3 or any later version.  
  * 
@@ -51,6 +51,15 @@ const char * const speed_grade_strings[] =
     "B",
     "C",
     "WifiRM2"
+};
+
+// must be in the same order as bluescsi_wifi_security_t in BlueSCSI_settings.h
+const char * const wifi_security_strings[] =
+{
+    "WPA2",
+    "WPA2AES",
+    "WPA3",
+    "WPA3WPA2"
 };
 
 // Helper function for case-insensitive string compare
@@ -757,6 +766,20 @@ bluescsi_speed_grade_t BlueSCSISettings::stringToSpeedGrade(const char *speed_gr
     }
 
     return grade;
+}
+
+bluescsi_wifi_security_t BlueSCSISettings::stringToWifiSecurity(const char *wifi_security_target)
+{
+    for (uint8_t i = 0; i < sizeof(wifi_security_strings)/sizeof(wifi_security_strings[0]); i++)
+    {
+        if (strequals(wifi_security_target, wifi_security_strings[i]))
+        {
+            return (bluescsi_wifi_security_t)i;
+        }
+    }
+
+    logmsg("Setting \"", wifi_security_target, "\" does not match any known Wi-Fi security mode, using WPA2");
+    return WIFI_SECURITY_WPA2;
 }
 
 const char *BlueSCSISettings::getSpeedGradeString()

--- a/src/BlueSCSI_settings.h
+++ b/src/BlueSCSI_settings.h
@@ -2,7 +2,7 @@
  * This file is originally part of ZuluSCSI adopted for BlueSCSI
  *
  * ZuluSCSI™ - Copyright (c) 2023-2025 Rabbit Hole Computing™
- * Copyright (c) 2023 Eric Helgeson
+ * Copyright (c) 2023-2026 Eric Helgeson <eric@bluescsi.com>
  * 
  * This file is licensed under the GPL version 3 or any later version.  
  * 
@@ -39,6 +39,18 @@ typedef enum
     SPEED_GRADE_BASE_203MHZ,
     SPEED_GRADE_BASE_155MHZ,
 } bluescsi_speed_grade_t;
+
+// Wi-Fi security mode requested by the WiFiSecurity setting.
+// WIFI_SECURITY_WPA2 must stay 0 so a zeroed S2S_BoardCfg keeps the
+// long-standing default when the setting is absent.
+// must be in the same order as wifi_security_strings[] in BlueSCSI_settings.cpp
+typedef enum
+{
+    WIFI_SECURITY_WPA2 = 0, // WPA/WPA2 mixed PSK, widest compatibility
+    WIFI_SECURITY_WPA2_AES, // WPA2 AES PSK only, refuses TKIP
+    WIFI_SECURITY_WPA3,     // WPA3 SAE only
+    WIFI_SECURITY_WPA3_WPA2,// WPA3 SAE, also programming the WPA2 PSK
+} bluescsi_wifi_security_t;
 
 #ifdef __cplusplus
 
@@ -178,6 +190,9 @@ public:
 
     // convert string to speed grade
     bluescsi_speed_grade_t stringToSpeedGrade(const char *speed_grade_str, size_t length);
+
+    // convert string to Wi-Fi security mode
+    bluescsi_wifi_security_t stringToWifiSecurity(const char *wifi_security_str);
 
     const char* getSpeedGradeString();
 


### PR DESCRIPTION
Fixes #406

Note while testing WPA2 always worked while WPA2/WPA3 transitional failed 1/4 of the time and WPA3 failed occasionally - so we'll let people opt in to WPA3 but until I see it more stable I'll leave the default the way it is. Also note that sometimes the auth failures are just stalls (which I attempted to log/address with a 30s timeout). 

Tested on a UniFi AP with WAP3 only, WAP2/3, and WAP2.