### PR TITLE
initiator: bound the wait-for-bus-free drain

### DIFF
--- a/lib/BlueSCSI_platform_RP2MCU/scsiHostPhy.cpp
+++ b/lib/BlueSCSI_platform_RP2MCU/scsiHostPhy.cpp
@@ -475,9 +475,11 @@ void scsiHostWaitBusFree()
     // Wait for the target to release BSY signal.
     // If the target is expecting more data, transfer dummy bytes.
     // This happens for some reason with READ6 command on IBM H3171-S2.
+    // A dead target holds BSY and REQ forever, so both loops need the deadline
+    // and the watchdog reset request or the drain below never returns.
     uint32_t start = platform_millis();
     int extra_bytes = 0;
-    while (SCSI_IN(BSY))
+    while (SCSI_IN(BSY) && !g_scsiHostPhyReset)
     {
         platform_poll();
 
@@ -487,7 +489,8 @@ void scsiHostWaitBusFree()
             // Transfer dummy bytes
              sleep_us(1);
 
-             while (SCSI_IN(REQ))
+             while (SCSI_IN(REQ) && !g_scsiHostPhyReset &&
+                    (uint32_t)(platform_millis() - start) <= 10000)
              {
                 scsiHostReadOneByte(nullptr);
                 extra_bytes++;

--- a/src/BlueSCSI_initiator.cpp
+++ b/src/BlueSCSI_initiator.cpp
@@ -402,9 +402,7 @@ void scsiInitiatorMainLoop()
             }
             else
             {
-#ifndef BLUESCSI_NETWORK
                 dbgmsg("Failed to connect to SCSI ID ", g_initiator_state.target_id);
-#endif
                 g_initiator_state.sectorsize = 0;
                 g_initiator_state.sectorcount = g_initiator_state.sectorcount_all = 0;
             }
@@ -758,9 +756,7 @@ int scsiInitiatorRunCommand(int target_id,
     if (!scsiHostPhySelect(target_id, g_initiator_state.initiator_id))
     {
         scsiHostPhySetATN(false);
-#ifndef BLUESCSI_NETWORK
         dbgmsg("------ Target ", target_id, " did not respond");
-#endif
         scsiHostPhyRelease();
         return -1;
     }
@@ -854,9 +850,7 @@ int scsiInitiatorRunCommand(int target_id,
             uint8_t tmp = -1;
             scsiHostRead(&tmp, 1);
             status = tmp;
-#ifndef BLUESCSI_NETWORK
             dbgmsg("------ STATUS: ", tmp);
-#endif
         }
     }
 


### PR DESCRIPTION
Regression since cd6d08b6; also adds back the initiator scan dbgmsgs on DaynaPORT.